### PR TITLE
refactor: use idiomatic result combinators across table modules

### DIFF
--- a/src/shelf.gleam
+++ b/src/shelf.gleam
@@ -34,7 +34,9 @@
 /// - No ordered set (DETS doesn't support it)
 /// - DETS performs disk I/O — `save()` has real latency
 ///
-/// Errors that can occur during shelf operations.
+/// ## Errors
+///
+/// Operations return `Result` with `ShelfError` for failures.
 pub type ShelfError {
   /// No value found for the given key
   NotFound

--- a/src/shelf/bag.gleam
+++ b/src/shelf/bag.gleam
@@ -17,6 +17,7 @@
 /// let assert Ok(Nil) = bag.close(table)
 /// ```
 ///
+import gleam/result
 import shelf.{
   type Config, type ShelfError, type WriteMode, Config, WriteBack, WriteThrough,
 }
@@ -33,10 +34,8 @@ pub opaque type PBag(k, v) {
 ///
 pub fn open_config(config: Config) -> Result(PBag(k, v), ShelfError) {
   let Config(name:, path:, write_mode:) = config
-  case ffi_open_bag(name, path) {
-    Ok(#(ets, dets)) -> Ok(PBag(ets:, dets:, write_mode:))
-    Error(err) -> Error(err)
-  }
+  ffi_open_bag(name, path)
+  |> result.map(fn(refs) { PBag(ets: refs.0, dets: refs.1, write_mode:) })
 }
 
 /// Open a persistent bag table with defaults (WriteBack mode).
@@ -70,14 +69,10 @@ pub fn with_table(
   path path: String,
   fun fun: fn(PBag(k, v)) -> Result(a, ShelfError),
 ) -> Result(a, ShelfError) {
-  case open(name:, path:) {
-    Ok(table) -> {
-      let result = fun(table)
-      let _ = close(table)
-      result
-    }
-    Error(err) -> Error(err)
-  }
+  use table <- result.try(open(name:, path:))
+  let result = fun(table)
+  let _ = close(table)
+  result
 }
 
 // ── Read ────────────────────────────────────────────────────────────────
@@ -132,10 +127,8 @@ pub fn insert(
   key key: k,
   value value: v,
 ) -> Result(Nil, ShelfError) {
-  case ffi_insert(table.ets, table.dets, #(key, value)) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_insert(table.ets, table.dets, #(key, value)))
+  maybe_write_through(table)
 }
 
 /// Insert multiple key-value pairs.
@@ -144,10 +137,8 @@ pub fn insert_list(
   into table: PBag(k, v),
   entries entries: List(#(k, v)),
 ) -> Result(Nil, ShelfError) {
-  case ffi_insert_list(table.ets, table.dets, entries) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_insert_list(table.ets, table.dets, entries))
+  maybe_write_through(table)
 }
 
 // ── Delete ──────────────────────────────────────────────────────────────
@@ -155,10 +146,8 @@ pub fn insert_list(
 /// Delete all values for the given key.
 ///
 pub fn delete_key(from table: PBag(k, v), key key: k) -> Result(Nil, ShelfError) {
-  case ffi_delete_key(table.ets, key) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_delete_key(table.ets, key))
+  maybe_write_through(table)
 }
 
 /// Delete a specific key-value pair.
@@ -171,19 +160,15 @@ pub fn delete_object(
   key key: k,
   value value: v,
 ) -> Result(Nil, ShelfError) {
-  case ffi_delete_object(table.ets, key, value) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_delete_object(table.ets, key, value))
+  maybe_write_through(table)
 }
 
 /// Delete all entries (keeps the table open).
 ///
 pub fn delete_all(from table: PBag(k, v)) -> Result(Nil, ShelfError) {
-  case ffi_delete_all(table.ets) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_delete_all(table.ets))
+  maybe_write_through(table)
 }
 
 // ── Persistence ─────────────────────────────────────────────────────────

--- a/src/shelf/duplicate_bag.gleam
+++ b/src/shelf/duplicate_bag.gleam
@@ -16,6 +16,7 @@
 /// let assert Ok(Nil) = duplicate_bag.close(table)
 /// ```
 ///
+import gleam/result
 import shelf.{
   type Config, type ShelfError, type WriteMode, Config, WriteBack, WriteThrough,
 }
@@ -32,10 +33,10 @@ pub opaque type PDuplicateBag(k, v) {
 ///
 pub fn open_config(config: Config) -> Result(PDuplicateBag(k, v), ShelfError) {
   let Config(name:, path:, write_mode:) = config
-  case ffi_open_duplicate_bag(name, path) {
-    Ok(#(ets, dets)) -> Ok(PDuplicateBag(ets:, dets:, write_mode:))
-    Error(err) -> Error(err)
-  }
+  ffi_open_duplicate_bag(name, path)
+  |> result.map(fn(refs) {
+    PDuplicateBag(ets: refs.0, dets: refs.1, write_mode:)
+  })
 }
 
 /// Open a persistent duplicate bag table with defaults (WriteBack mode).
@@ -69,14 +70,10 @@ pub fn with_table(
   path path: String,
   fun fun: fn(PDuplicateBag(k, v)) -> Result(a, ShelfError),
 ) -> Result(a, ShelfError) {
-  case open(name:, path:) {
-    Ok(table) -> {
-      let result = fun(table)
-      let _ = close(table)
-      result
-    }
-    Error(err) -> Error(err)
-  }
+  use table <- result.try(open(name:, path:))
+  let result = fun(table)
+  let _ = close(table)
+  result
 }
 
 // ── Read ────────────────────────────────────────────────────────────────
@@ -139,10 +136,8 @@ pub fn insert(
   key key: k,
   value value: v,
 ) -> Result(Nil, ShelfError) {
-  case ffi_insert(table.ets, table.dets, #(key, value)) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_insert(table.ets, table.dets, #(key, value)))
+  maybe_write_through(table)
 }
 
 /// Insert multiple key-value pairs.
@@ -151,10 +146,8 @@ pub fn insert_list(
   into table: PDuplicateBag(k, v),
   entries entries: List(#(k, v)),
 ) -> Result(Nil, ShelfError) {
-  case ffi_insert_list(table.ets, table.dets, entries) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_insert_list(table.ets, table.dets, entries))
+  maybe_write_through(table)
 }
 
 // ── Delete ──────────────────────────────────────────────────────────────
@@ -165,10 +158,8 @@ pub fn delete_key(
   from table: PDuplicateBag(k, v),
   key key: k,
 ) -> Result(Nil, ShelfError) {
-  case ffi_delete_key(table.ets, key) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_delete_key(table.ets, key))
+  maybe_write_through(table)
 }
 
 /// Delete a specific key-value pair.
@@ -181,19 +172,15 @@ pub fn delete_object(
   key key: k,
   value value: v,
 ) -> Result(Nil, ShelfError) {
-  case ffi_delete_object(table.ets, key, value) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_delete_object(table.ets, key, value))
+  maybe_write_through(table)
 }
 
 /// Delete all entries (keeps the table open).
 ///
 pub fn delete_all(from table: PDuplicateBag(k, v)) -> Result(Nil, ShelfError) {
-  case ffi_delete_all(table.ets) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_delete_all(table.ets))
+  maybe_write_through(table)
 }
 
 // ── Persistence ─────────────────────────────────────────────────────────

--- a/src/shelf/internal.gleam
+++ b/src/shelf/internal.gleam
@@ -6,8 +6,3 @@ pub type EtsRef
 
 /// Raw DETS table reference (Erlang atom).
 pub type DetsRef
-
-/// A pair of ETS + DETS references returned by the FFI open functions.
-pub type TableRefs {
-  TableRefs(ets: EtsRef, dets: DetsRef)
-}

--- a/src/shelf/set.gleam
+++ b/src/shelf/set.gleam
@@ -16,6 +16,7 @@
 /// let assert Ok(Nil) = set.close(table)   // auto-saves on close
 /// ```
 ///
+import gleam/result
 import shelf.{
   type Config, type ShelfError, type WriteMode, Config, WriteBack, WriteThrough,
 }
@@ -45,10 +46,8 @@ pub opaque type PSet(k, v) {
 ///
 pub fn open_config(config: Config) -> Result(PSet(k, v), ShelfError) {
   let Config(name:, path:, write_mode:) = config
-  case ffi_open_set(name, path) {
-    Ok(#(ets, dets)) -> Ok(PSet(ets:, dets:, write_mode:))
-    Error(err) -> Error(err)
-  }
+  ffi_open_set(name, path)
+  |> result.map(fn(refs) { PSet(ets: refs.0, dets: refs.1, write_mode:) })
 }
 
 /// Open a persistent set table with defaults (WriteBack mode).
@@ -88,14 +87,10 @@ pub fn with_table(
   path path: String,
   fun fun: fn(PSet(k, v)) -> Result(a, ShelfError),
 ) -> Result(a, ShelfError) {
-  case open(name:, path:) {
-    Ok(table) -> {
-      let result = fun(table)
-      let _ = close(table)
-      result
-    }
-    Error(err) -> Error(err)
-  }
+  use table <- result.try(open(name:, path:))
+  let result = fun(table)
+  let _ = close(table)
+  result
 }
 
 // ── Read (always from ETS — fast) ───────────────────────────────────────
@@ -156,10 +151,8 @@ pub fn insert(
   key key: k,
   value value: v,
 ) -> Result(Nil, ShelfError) {
-  case ffi_insert(table.ets, table.dets, #(key, value)) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_insert(table.ets, table.dets, #(key, value)))
+  maybe_write_through(table)
 }
 
 /// Insert multiple key-value pairs at once.
@@ -168,10 +161,8 @@ pub fn insert_list(
   into table: PSet(k, v),
   entries entries: List(#(k, v)),
 ) -> Result(Nil, ShelfError) {
-  case ffi_insert_list(table.ets, table.dets, entries) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_insert_list(table.ets, table.dets, entries))
+  maybe_write_through(table)
 }
 
 /// Insert a key-value pair only if the key does not already exist.
@@ -183,10 +174,8 @@ pub fn insert_new(
   key key: k,
   value value: v,
 ) -> Result(Nil, ShelfError) {
-  case ffi_insert_new(table.ets, table.dets, #(key, value)) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_insert_new(table.ets, table.dets, #(key, value)))
+  maybe_write_through(table)
 }
 
 // ── Delete ──────────────────────────────────────────────────────────────
@@ -194,10 +183,8 @@ pub fn insert_new(
 /// Delete the entry with the given key.
 ///
 pub fn delete_key(from table: PSet(k, v), key key: k) -> Result(Nil, ShelfError) {
-  case ffi_delete_key(table.ets, key) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_delete_key(table.ets, key))
+  maybe_write_through(table)
 }
 
 /// Delete a specific key-value pair.
@@ -210,19 +197,15 @@ pub fn delete_object(
   key key: k,
   value value: v,
 ) -> Result(Nil, ShelfError) {
-  case ffi_delete_object(table.ets, key, value) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_delete_object(table.ets, key, value))
+  maybe_write_through(table)
 }
 
 /// Delete all entries (keeps the table open).
 ///
 pub fn delete_all(from table: PSet(k, v)) -> Result(Nil, ShelfError) {
-  case ffi_delete_all(table.ets) {
-    Ok(Nil) -> maybe_write_through(table)
-    Error(err) -> Error(err)
-  }
+  use _ <- result.try(ffi_delete_all(table.ets))
+  maybe_write_through(table)
 }
 
 // ── Persistence ─────────────────────────────────────────────────────────
@@ -281,17 +264,13 @@ pub fn update_counter(
   key key: k,
   increment amount: Int,
 ) -> Result(Int, ShelfError) {
-  case ffi_update_counter(table.ets, key, amount) {
-    Ok(new_val) -> {
-      case table.write_mode {
-        WriteThrough -> {
-          let _ = ffi_save(table.ets, table.dets)
-          Ok(new_val)
-        }
-        WriteBack -> Ok(new_val)
-      }
+  use new_val <- result.try(ffi_update_counter(table.ets, key, amount))
+  case table.write_mode {
+    WriteThrough -> {
+      let _ = ffi_save(table.ets, table.dets)
+      Ok(new_val)
     }
-    Error(err) -> Error(err)
+    WriteBack -> Ok(new_val)
   }
 }
 

--- a/test/bag_test.gleam
+++ b/test/bag_test.gleam
@@ -1,5 +1,6 @@
 import gleam/dynamic.{type Dynamic}
 import gleam/list
+import gleam/string
 import shelf
 import shelf/bag
 import startest.{describe, it}
@@ -33,7 +34,7 @@ pub fn bag_tests() {
         let assert Ok(Nil) = bag.insert(table, "color", "red")
         let assert Ok(Nil) = bag.insert(table, "color", "blue")
         let assert Ok(values) = bag.lookup(table, "color")
-        let sorted = list.sort(values, string_compare)
+        let sorted = list.sort(values, string.compare)
         expect.to_equal(sorted, ["blue", "red"])
         let assert Ok(Nil) = bag.close(table)
         cleanup(path)
@@ -90,11 +91,3 @@ pub fn bag_tests() {
     ]),
   ])
 }
-
-import gleam/string
-
-fn string_compare(a: String, b: String) -> order.Order {
-  string.compare(a, b)
-}
-
-import gleam/order

--- a/test/set_test.gleam
+++ b/test/set_test.gleam
@@ -1,5 +1,6 @@
 import gleam/dynamic.{type Dynamic}
 import gleam/list
+import gleam/string
 import shelf
 import shelf/set
 import startest.{describe, it}
@@ -136,7 +137,7 @@ pub fn set_tests() {
         let assert Ok(table) = set.open(name: "set_to_list", path: path)
         let assert Ok(Nil) = set.insert_list(table, [#("a", 1), #("b", 2)])
         let assert Ok(entries) = set.to_list(table)
-        let sorted = list.sort(entries, fn(a, b) { string_compare(a.0, b.0) })
+        let sorted = list.sort(entries, fn(a, b) { string.compare(a.0, b.0) })
         expect.to_equal(sorted, [#("a", 1), #("b", 2)])
         let assert Ok(Nil) = set.close(table)
         cleanup(path)
@@ -184,11 +185,3 @@ pub fn set_tests() {
     ]),
   ])
 }
-
-import gleam/string
-
-fn string_compare(a: String, b: String) -> order.Order {
-  string.compare(a, b)
-}
-
-import gleam/order


### PR DESCRIPTION
## Summary

- Replace manual `case ... { Ok(x) -> ...; Error(err) -> Error(err) }` with `result.try` and `result.map` across all three table modules (set, bag, duplicate_bag) — eliminates ~66 lines of boilerplate
- Remove unused `TableRefs` type from `internal.gleam`
- Inline trivial `string_compare` wrappers in test files and fix scattered imports
- Improve doc comment structure in `shelf.gleam`