### PR TITLE
docs: fix critical gaps and fill website guide pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,18 @@ Writes go to ETS only. You control when to persist:
 let assert Ok(table) = set.open(name: "sessions", path: "data/sessions.dets")
 
 // These are ETS-only (fast)
-set.insert(table, "user:123", session)
-set.insert(table, "user:456", session)
+let assert Ok(Nil) = set.insert(table, "user:123", session)
+let assert Ok(Nil) = set.insert(table, "user:456", session)
 
 // Persist when ready (e.g., on a timer, after N writes)
-set.save(table)
+let assert Ok(Nil) = set.save(table)
 
 // Undo unsaved changes
-set.reload(table)
+let assert Ok(Nil) = set.reload(table)
 ```
+
+> **Note**: In WriteBack mode, data written since the last `save()` is lost if the process crashes.
+> Design your save schedule accordingly (e.g., periodic timer, after N writes, or at clean shutdown).
 
 ### WriteThrough
 
@@ -111,20 +114,23 @@ let config =
 let assert Ok(table) = set.open_config(config)
 
 // This writes to both ETS and DETS
-set.insert(table, "acct:789", account)
+let assert Ok(Nil) = set.insert(table, "acct:789", account)
 ```
 
 ## Table Types
 
 ### Set — unique keys
 
+Each table type uses an opaque handle — `PSet(k, v)`, `PBag(k, v)`, or `PDuplicateBag(k, v)` — where "P" stands for "Persistent".
+
 ```gleam
 import shelf/set
 
 let assert Ok(t) = set.open(name: "cache", path: "cache.dets")
-set.insert(t, "key", "value")       // overwrites if exists
-set.insert_new(t, "key", "value2")  // fails if exists
-set.lookup(t, "key")                // Ok("value")
+let assert Ok(Nil) = set.insert(t, "key", "value")       // overwrites if exists
+let assert Ok(Nil) = set.insert_new(t, "key", "value2")  // Error(KeyAlreadyPresent)
+let assert Ok("value") = set.lookup(t, "key")
+let assert Ok(True) = set.member(of: t, key: "key")      // check existence
 ```
 
 ### Bag — multiple distinct values per key
@@ -133,10 +139,10 @@ set.lookup(t, "key")                // Ok("value")
 import shelf/bag
 
 let assert Ok(t) = bag.open(name: "tags", path: "tags.dets")
-bag.insert(t, "color", "red")
-bag.insert(t, "color", "blue")
-bag.insert(t, "color", "red")    // ignored (duplicate)
-bag.lookup(t, "color")           // Ok(["red", "blue"])
+let assert Ok(Nil) = bag.insert(t, "color", "red")
+let assert Ok(Nil) = bag.insert(t, "color", "blue")
+let assert Ok(Nil) = bag.insert(t, "color", "red")    // ignored (duplicate)
+let assert Ok(["red", "blue"]) = bag.lookup(t, "color")
 ```
 
 ### Duplicate Bag — duplicates allowed
@@ -145,10 +151,29 @@ bag.lookup(t, "color")           // Ok(["red", "blue"])
 import shelf/duplicate_bag
 
 let assert Ok(t) = duplicate_bag.open(name: "events", path: "events.dets")
-duplicate_bag.insert(t, "click", "btn")
-duplicate_bag.insert(t, "click", "btn")  // kept!
-duplicate_bag.lookup(t, "click")         // Ok(["btn", "btn"])
+let assert Ok(Nil) = duplicate_bag.insert(t, "click", "btn")
+let assert Ok(Nil) = duplicate_bag.insert(t, "click", "btn")  // kept!
+let assert Ok(["btn", "btn"]) = duplicate_bag.lookup(t, "click")
 ```
+
+### API Comparison
+
+Not all operations are available on every table type:
+
+| Operation | Set | Bag | Duplicate Bag |
+|-----------|-----|-----|---------------|
+| `insert` | ✅ | ✅ | ✅ |
+| `insert_list` | ✅ | ✅ | ✅ |
+| `insert_new` | ✅ | — | — |
+| `lookup` | single value | `List(v)` | `List(v)` |
+| `member` | ✅ | ✅ | ✅ |
+| `delete_key` | ✅ | ✅ | ✅ |
+| `delete_object` | ✅ | ✅ | ✅ |
+| `delete_all` | ✅ | ✅ | ✅ |
+| `update_counter` | ✅ | — | — |
+| `fold` | ✅ | ✅ | ✅ |
+| `size` | ✅ | ✅ | ✅ |
+| `to_list` | ✅ | ✅ | ✅ |
 
 ## Safe Resource Management
 
@@ -168,6 +193,31 @@ set.insert(table, "key", "value")
 | `reload(table)` | Discard ETS, reload from DETS |
 | `sync(table)` | Flush DETS write buffer to OS |
 | `close(table)` | Save + close DETS + delete ETS |
+
+**`save` vs `sync`**: `save()` copies ETS contents into DETS — use this in WriteBack mode to persist your changes. `sync()` flushes DETS's internal write buffer to the OS filesystem — use this in WriteThrough mode when you need to guarantee durability after a write (DETS buffers writes for performance).
+
+## Error Handling
+
+All operations return `Result(value, ShelfError)`. The error type covers all failure modes:
+
+| Error | Cause |
+|-------|-------|
+| `NotFound` | Key doesn't exist (from `lookup`) |
+| `KeyAlreadyPresent` | Key exists (from `insert_new`) |
+| `TableClosed` | Table has been closed or doesn't exist |
+| `NameConflict` | An ETS table with this name is already open |
+| `FileError(String)` | DETS file couldn't be found, created, or opened |
+| `FileSizeLimitExceeded` | DETS file exceeds the 2 GB limit |
+| `ErlangError(String)` | Catch-all for unexpected Erlang-level errors |
+
+```gleam
+case set.open(name: "cache", path: "data/cache.dets") {
+  Ok(table) -> use_table(table)
+  Error(shelf.NameConflict) -> io.println("Table already open!")
+  Error(shelf.FileError(msg)) -> io.println("File error: " <> msg)
+  Error(err) -> io.println("Unexpected: " <> string.inspect(err))
+}
+```
 
 ## Atomic Counters
 
@@ -192,10 +242,6 @@ set.update_counter(t, "page_views", 10)  // Ok(11)
 - **[slate](https://hex.pm/packages/slate)** — Use DETS directly when you don't need in-memory speed
 - **[Erlang ETS docs](https://www.erlang.org/doc/apps/stdlib/ets.html)** — Underlying ETS documentation
 - **[Erlang DETS docs](https://www.erlang.org/doc/apps/stdlib/dets.html)** — Underlying DETS documentation
-
-## Target
-
-This package only supports the Erlang target.
 
 ## Development
 

--- a/src/shelf.gleam
+++ b/src/shelf.gleam
@@ -10,7 +10,7 @@
 /// import shelf
 /// import shelf/set
 ///
-/// let assert Ok(table) = set.open("cache", "data/cache.dets")
+/// let assert Ok(table) = set.open(name: "cache", path: "data/cache.dets")
 /// let assert Ok(Nil) = set.insert(table, "key", "value")
 /// let assert Ok("value") = set.lookup(table, "key")
 /// let assert Ok(Nil) = set.save(table)   // persist to disk

--- a/src/shelf/bag.gleam
+++ b/src/shelf/bag.gleam
@@ -9,7 +9,7 @@
 /// ```gleam
 /// import shelf/bag
 ///
-/// let assert Ok(table) = bag.open("tags", "data/tags.dets")
+/// let assert Ok(table) = bag.open(name: "tags", path: "data/tags.dets")
 /// let assert Ok(Nil) = bag.insert(table, "color", "red")
 /// let assert Ok(Nil) = bag.insert(table, "color", "blue")
 /// let assert Ok(["red", "blue"]) = bag.lookup(table, "color")
@@ -41,7 +41,7 @@ pub fn open_config(config: Config) -> Result(PBag(k, v), ShelfError) {
 /// Open a persistent bag table with defaults (WriteBack mode).
 ///
 /// ```gleam
-/// let assert Ok(table) = bag.open("tags", "data/tags.dets")
+/// let assert Ok(table) = bag.open(name: "tags", path: "data/tags.dets")
 /// ```
 ///
 pub fn open(

--- a/src/shelf/duplicate_bag.gleam
+++ b/src/shelf/duplicate_bag.gleam
@@ -9,7 +9,7 @@
 /// ```gleam
 /// import shelf/duplicate_bag
 ///
-/// let assert Ok(table) = duplicate_bag.open("events", "data/events.dets")
+/// let assert Ok(table) = duplicate_bag.open(name: "events", path: "data/events.dets")
 /// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "btn_1")
 /// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "btn_1")
 /// let assert Ok(["btn_1", "btn_1"]) = duplicate_bag.lookup(table, "click")
@@ -42,7 +42,7 @@ pub fn open_config(config: Config) -> Result(PDuplicateBag(k, v), ShelfError) {
 /// Open a persistent duplicate bag table with defaults (WriteBack mode).
 ///
 /// ```gleam
-/// let assert Ok(table) = duplicate_bag.open("events", "data/events.dets")
+/// let assert Ok(table) = duplicate_bag.open(name: "events", path: "data/events.dets")
 /// ```
 ///
 pub fn open(

--- a/src/shelf/set.gleam
+++ b/src/shelf/set.gleam
@@ -9,7 +9,7 @@
 /// ```gleam
 /// import shelf/set
 ///
-/// let assert Ok(table) = set.open("users", "data/users.dets")
+/// let assert Ok(table) = set.open(name: "users", path: "data/users.dets")
 /// let assert Ok(Nil) = set.insert(table, "alice", 42)
 /// let assert Ok(42) = set.lookup(table, "alice")
 /// let assert Ok(Nil) = set.save(table)    // persist to disk
@@ -53,7 +53,7 @@ pub fn open_config(config: Config) -> Result(PSet(k, v), ShelfError) {
 /// Open a persistent set table with defaults (WriteBack mode).
 ///
 /// ```gleam
-/// let assert Ok(table) = set.open("users", "data/users.dets")
+/// let assert Ok(table) = set.open(name: "users", path: "data/users.dets")
 /// ```
 ///
 pub fn open(

--- a/website/src/content/docs/advanced/limitations.md
+++ b/website/src/content/docs/advanced/limitations.md
@@ -3,4 +3,70 @@ title: Limitations
 description: Known limitations of shelf and its underlying storage engines.
 ---
 
-TODO: Write limitations guide.
+shelf inherits limitations from its underlying storage engines (ETS and DETS). Understanding these helps you design your application correctly.
+
+## DETS File Size: 2 GB Maximum
+
+DETS files are limited to 2 GB. Operations that would exceed this limit return `Error(FileSizeLimitExceeded)`.
+
+If you need more than 2 GB of persistent data, consider:
+- Splitting data across multiple tables
+- Using a database (PostgreSQL, SQLite) for large datasets
+- Using Mnesia for distributed storage
+
+## No Ordered Set
+
+DETS does not support the `ordered_set` table type. Only `set`, `bag`, and `duplicate_bag` are available through shelf.
+
+If you need ordered iteration, use `to_list()` and sort the results in your application code.
+
+## Erlang Only
+
+shelf requires the BEAM runtime (Erlang/OTP) and does not support the JavaScript target. This is inherent — ETS and DETS are Erlang VM features.
+
+**Requirements**: Erlang/OTP >= 26 (recommended: 27+)
+
+## Single Node
+
+DETS is local to one Erlang node. Data is not replicated or distributed. For multi-node persistence, consider:
+- **Mnesia** — Built-in distributed database for Erlang
+- **Raft-based solutions** — For consensus-based replication
+
+## Table Names Must Be Unique
+
+ETS table names are VM-global atoms. If you try to open a table with a name that's already in use by another ETS table (from shelf or any other library), you'll get `Error(NameConflict)`.
+
+Use descriptive, namespaced names to avoid collisions:
+
+```gleam
+// Good — namespaced
+set.open(name: "myapp_user_sessions", path: "data/sessions.dets")
+
+// Risky — generic name might collide
+set.open(name: "cache", path: "data/cache.dets")
+```
+
+## Process Ownership
+
+ETS tables are owned by the process that created them. If that process crashes or exits, the ETS table is automatically deleted — any unsaved data is lost. The DETS file on disk remains intact.
+
+When the application restarts and calls `open()` again, data is reloaded from the DETS file.
+
+To mitigate this:
+- Use `with_table` for short-lived operations
+- In long-running applications, ensure the process that opens tables is supervised
+- Use WriteThrough mode for critical data to minimize the window of potential data loss
+
+## Error Handling
+
+All shelf operations return `Result(value, ShelfError)`. The error variants are:
+
+| Error | Cause |
+|-------|-------|
+| `NotFound` | Key doesn't exist (from `lookup`) |
+| `KeyAlreadyPresent` | Key exists (from `insert_new`, set tables only) |
+| `TableClosed` | Table has been closed or doesn't exist |
+| `NameConflict` | An ETS table with this name is already open |
+| `FileError(String)` | DETS file couldn't be found, created, or opened |
+| `FileSizeLimitExceeded` | DETS file exceeds the 2 GB limit |
+| `ErlangError(String)` | Catch-all for unexpected Erlang-level errors |

--- a/website/src/content/docs/advanced/persistence-operations.md
+++ b/website/src/content/docs/advanced/persistence-operations.md
@@ -3,4 +3,89 @@ title: Persistence Operations
 description: Save, reload, sync, and close operations for managing data persistence.
 ---
 
-TODO: Write persistence operations guide.
+shelf provides four persistence operations to control how and when data moves between memory (ETS) and disk (DETS).
+
+## Overview
+
+| Function | Behavior |
+|----------|----------|
+| `save(table)` | Snapshot ETS → DETS (replaces DETS contents) |
+| `reload(table)` | Discard ETS, reload from DETS |
+| `sync(table)` | Flush DETS write buffer to OS |
+| `close(table)` | Save + close DETS + delete ETS |
+
+## save
+
+Atomically snapshots the entire ETS table into DETS, replacing all DETS contents with the current ETS state. Uses `ets:to_dets/2` internally — the transfer happens efficiently inside the Erlang VM without materializing the table as a list.
+
+```gleam
+// After a batch of writes...
+let assert Ok(Nil) = set.save(table)
+```
+
+**When to use**: In WriteBack mode, call `save()` to persist changes to disk. Common strategies:
+- On a periodic timer (e.g., every 30 seconds)
+- After a batch of N writes
+- At application shutdown
+- After critical data changes
+
+In WriteThrough mode, `save()` is called automatically after every write, so you rarely need to call it manually.
+
+## reload
+
+Clears the ETS table and loads all DETS contents into it. Discards any unsaved changes in ETS.
+
+```gleam
+// Undo unsaved changes
+let assert Ok(Nil) = set.reload(table)
+```
+
+**When to use**: In WriteBack mode, use `reload()` to discard in-memory changes and revert to the last saved state. In WriteThrough mode, ETS and DETS are always in sync, so `reload()` is rarely needed.
+
+## sync
+
+Flushes the DETS internal write buffer to the OS filesystem. DETS buffers writes for performance — `sync()` forces those buffers to disk.
+
+```gleam
+let assert Ok(Nil) = set.sync(table)
+```
+
+**When to use**: In WriteThrough mode, after a critical write when you need to guarantee the data has reached the filesystem. In WriteBack mode, `sync()` is less useful since you control persistence via `save()`.
+
+:::note[save vs sync]
+`save()` copies data from ETS into DETS. `sync()` flushes DETS's internal buffer to the OS. They serve different purposes:
+- After `save()`: data is in DETS but may be in OS buffers
+- After `sync()`: data is flushed from DETS buffers to the filesystem
+- For maximum durability: call `save()` then `sync()`
+:::
+
+## close
+
+Performs a final `save()`, closes the DETS file, and deletes the ETS table. The table handle must not be used after closing.
+
+```gleam
+let assert Ok(Nil) = set.close(table)
+```
+
+For guaranteed cleanup, use `with_table` instead of manual open/close:
+
+```gleam
+let assert Ok(Nil) = {
+  use table <- set.with_table("cache", "data/cache.dets")
+  set.insert(into: table, key: "key", value: "value")
+}
+// table is automatically closed here
+```
+
+## Persistence Flow
+
+```
+WriteBack mode:
+  insert → ETS only
+  save() → ETS ──snapshot──→ DETS
+  sync() → DETS ──flush──→ filesystem
+
+WriteThrough mode:
+  insert → ETS + automatic save() → DETS
+  sync() → DETS ──flush──→ filesystem
+```

--- a/website/src/content/docs/guides/bag-tables.md
+++ b/website/src/content/docs/guides/bag-tables.md
@@ -3,4 +3,97 @@ title: Bag Tables
 description: Multiple distinct values per key with persistent bag tables.
 ---
 
-TODO: Write bag tables guide.
+Bag tables store multiple values per key, but silently ignore duplicate key-value pairs. Use bags when you need to associate several distinct values with a single key — like tags, categories, or group memberships.
+
+## Opening a Bag Table
+
+```gleam
+import shelf/bag
+
+let assert Ok(table) = bag.open(name: "tags", path: "data/tags.dets")
+```
+
+For custom configuration, use `open_config`:
+
+```gleam
+import shelf
+import shelf/bag
+
+let config =
+  shelf.config(name: "tags", path: "data/tags.dets")
+  |> shelf.write_mode(shelf.WriteThrough)
+
+let assert Ok(table) = bag.open_config(config)
+```
+
+## Reading Data
+
+```gleam
+// Look up all values for a key (returns a list)
+let assert Ok(colors) = bag.lookup(from: table, key: "color")
+// colors: ["red", "blue"]
+
+// Check if a key exists
+let assert Ok(True) = bag.member(of: table, key: "color")
+
+// Get the total number of objects (not unique keys)
+let assert Ok(count) = bag.size(of: table)
+
+// Get all entries
+let assert Ok(entries) = bag.to_list(from: table)
+```
+
+### Folding
+
+```gleam
+let assert Ok(all_values) =
+  bag.fold(over: table, from: [], with: fn(acc, _key, value) {
+    [value, ..acc]
+  })
+```
+
+## Writing Data
+
+```gleam
+// Insert a key-value pair
+let assert Ok(Nil) = bag.insert(into: table, key: "color", value: "red")
+let assert Ok(Nil) = bag.insert(into: table, key: "color", value: "blue")
+
+// Duplicate key-value pairs are silently ignored
+let assert Ok(Nil) = bag.insert(into: table, key: "color", value: "red")
+// "color" still has ["red", "blue"]
+
+// Insert multiple entries at once
+let assert Ok(Nil) = bag.insert_list(into: table, entries: [
+  #("shape", "circle"),
+  #("shape", "square"),
+])
+```
+
+:::note
+Unlike set tables, bag tables do **not** support `insert_new` or `update_counter`.
+:::
+
+## Deleting Data
+
+```gleam
+// Delete all values for a key
+let assert Ok(Nil) = bag.delete_key(from: table, key: "color")
+
+// Delete a specific key-value pair (other values for the same key are kept)
+let assert Ok(Nil) = bag.delete_object(from: table, key: "shape", value: "circle")
+// "shape" still has ["square"]
+
+// Delete all entries
+let assert Ok(Nil) = bag.delete_all(from: table)
+```
+
+## Bag vs Set
+
+| Behavior | Set | Bag |
+|----------|-----|-----|
+| Values per key | One (overwrites) | Many (distinct only) |
+| `lookup` returns | Single value | `List(v)` |
+| Duplicate pairs | Overwrites | Silently ignored |
+| `insert_new` | ✅ | — |
+| `update_counter` | ✅ | — |

--- a/website/src/content/docs/guides/duplicate-bag-tables.md
+++ b/website/src/content/docs/guides/duplicate-bag-tables.md
@@ -3,4 +3,96 @@ title: Duplicate Bag Tables
 description: Persistent tables that allow duplicate key-value pairs.
 ---
 
-TODO: Write duplicate bag tables guide.
+Duplicate bag tables are like bag tables, but they preserve duplicate key-value pairs. Use these when you need to record every occurrence — event logs, audit trails, or time-series data.
+
+## Opening a Duplicate Bag Table
+
+```gleam
+import shelf/duplicate_bag
+
+let assert Ok(table) = duplicate_bag.open(name: "events", path: "data/events.dets")
+```
+
+For custom configuration, use `open_config`:
+
+```gleam
+import shelf
+import shelf/duplicate_bag
+
+let config =
+  shelf.config(name: "events", path: "data/events.dets")
+  |> shelf.write_mode(shelf.WriteThrough)
+
+let assert Ok(table) = duplicate_bag.open_config(config)
+```
+
+## Reading Data
+
+```gleam
+// Look up all values for a key (returns a list, including duplicates)
+let assert Ok(clicks) = duplicate_bag.lookup(from: table, key: "click")
+// clicks: ["btn_1", "btn_1", "btn_2"]
+
+// Check if a key exists
+let assert Ok(True) = duplicate_bag.member(of: table, key: "click")
+
+// Get the total number of objects (counts duplicates)
+let assert Ok(count) = duplicate_bag.size(of: table)
+
+// Get all entries
+let assert Ok(entries) = duplicate_bag.to_list(from: table)
+```
+
+### Folding
+
+```gleam
+let assert Ok(click_count) =
+  duplicate_bag.fold(over: table, from: 0, with: fn(acc, key, _value) {
+    case key == "click" {
+      True -> acc + 1
+      False -> acc
+    }
+  })
+```
+
+## Writing Data
+
+```gleam
+// Insert a key-value pair
+let assert Ok(Nil) = duplicate_bag.insert(into: table, key: "click", value: "btn_1")
+
+// Duplicates are preserved!
+let assert Ok(Nil) = duplicate_bag.insert(into: table, key: "click", value: "btn_1")
+// "click" now has ["btn_1", "btn_1"]
+
+// Insert multiple entries at once
+let assert Ok(Nil) = duplicate_bag.insert_list(into: table, entries: [
+  #("hover", "menu"),
+  #("hover", "menu"),
+])
+```
+
+:::note
+Like bag tables, duplicate bag tables do **not** support `insert_new` or `update_counter`.
+:::
+
+## Deleting Data
+
+```gleam
+// Delete all values for a key
+let assert Ok(Nil) = duplicate_bag.delete_key(from: table, key: "click")
+
+// Delete a specific key-value pair (removes matching occurrences)
+let assert Ok(Nil) = duplicate_bag.delete_object(from: table, key: "hover", value: "menu")
+
+// Delete all entries
+let assert Ok(Nil) = duplicate_bag.delete_all(from: table)
+```
+
+## Bag vs Duplicate Bag
+
+| Behavior | Bag | Duplicate Bag |
+|----------|-----|---------------|
+| Duplicate pairs | Silently ignored | Preserved |
+| Use case | Distinct associations | Event logs, audit trails |
+| `lookup` returns | Distinct values only | All values including duplicates |

--- a/website/src/content/docs/guides/set-tables.md
+++ b/website/src/content/docs/guides/set-tables.md
@@ -3,4 +3,115 @@ title: Set Tables
 description: Unique key-value storage with persistent set tables.
 ---
 
-TODO: Write set tables guide.
+Set tables store one value per key — inserting with an existing key overwrites the previous value. This is the most common table type, equivalent to a persistent key-value store.
+
+## Opening a Set Table
+
+```gleam
+import shelf/set
+
+let assert Ok(table) = set.open(name: "users", path: "data/users.dets")
+```
+
+If the DETS file exists, its contents are loaded into ETS automatically. If the file doesn't exist, both tables start empty.
+
+For custom configuration (e.g., WriteThrough mode), use `open_config`:
+
+```gleam
+import shelf
+import shelf/set
+
+let config =
+  shelf.config(name: "users", path: "data/users.dets")
+  |> shelf.write_mode(shelf.WriteThrough)
+
+let assert Ok(table) = set.open_config(config)
+```
+
+## Reading Data
+
+```gleam
+// Look up a single value
+let assert Ok(value) = set.lookup(from: table, key: "alice")
+
+// Check if a key exists (without fetching the value)
+let assert Ok(True) = set.member(of: table, key: "alice")
+
+// Get the number of entries
+let assert Ok(count) = set.size(of: table)
+
+// Get all entries as a list (loads entire table into memory)
+let assert Ok(entries) = set.to_list(from: table)
+```
+
+### Folding
+
+Fold over all entries to compute an aggregate. Order is unspecified.
+
+```gleam
+let assert Ok(total) =
+  set.fold(over: table, from: 0, with: fn(acc, _key, value) {
+    acc + value
+  })
+```
+
+## Writing Data
+
+```gleam
+// Insert or overwrite
+let assert Ok(Nil) = set.insert(into: table, key: "alice", value: 42)
+
+// Insert only if key doesn't exist — returns Error(KeyAlreadyPresent) otherwise
+let assert Ok(Nil) = set.insert_new(into: table, key: "bob", value: 99)
+
+// Insert multiple entries at once
+let assert Ok(Nil) = set.insert_list(into: table, entries: [
+  #("charlie", 10),
+  #("diana", 20),
+])
+```
+
+:::note
+`insert_new` is unique to set tables — bag and duplicate bag tables don't support it.
+:::
+
+## Deleting Data
+
+```gleam
+// Delete by key
+let assert Ok(Nil) = set.delete_key(from: table, key: "alice")
+
+// Delete a specific key-value pair (equivalent to delete_key for sets)
+let assert Ok(Nil) = set.delete_object(from: table, key: "bob", value: 99)
+
+// Delete all entries (keeps the table open)
+let assert Ok(Nil) = set.delete_all(from: table)
+```
+
+## Atomic Counters
+
+Set tables support atomic integer counters — useful for metrics, rate limiting, or any lock-free counting:
+
+```gleam
+let assert Ok(Nil) = set.insert(into: table, key: "page_views", value: 0)
+let assert Ok(1) = set.update_counter(in: table, key: "page_views", increment: 1)
+let assert Ok(11) = set.update_counter(in: table, key: "page_views", increment: 10)
+let assert Ok(9) = set.update_counter(in: table, key: "page_views", increment: -2)
+```
+
+:::note
+`update_counter` is unique to set tables and requires integer values.
+:::
+
+## Resource Management
+
+Use `with_table` to ensure a table is always closed, even if an error occurs:
+
+```gleam
+let assert Ok(Nil) = {
+  use table <- set.with_table("cache", "data/cache.dets")
+  set.insert(into: table, key: "key", value: "value")
+}
+```
+
+The callback must return `Result(a, ShelfError)`. The table is closed after the callback returns.

--- a/website/src/content/docs/guides/write-modes.md
+++ b/website/src/content/docs/guides/write-modes.md
@@ -3,4 +3,97 @@ title: Write Modes
 description: Choose between WriteBack and WriteThrough persistence strategies.
 ---
 
-TODO: Write write modes guide.
+shelf supports two write modes that control when data is persisted to disk. Choose the mode that matches your durability and performance requirements.
+
+## WriteBack (Default)
+
+In WriteBack mode, writes go to ETS (memory) only. Data is persisted to DETS (disk) when you explicitly call `save()`, or automatically when the table is closed.
+
+```gleam
+import shelf/set
+
+let assert Ok(table) = set.open(name: "sessions", path: "data/sessions.dets")
+
+// Fast writes — ETS only
+let assert Ok(Nil) = set.insert(table, "user:1", session_1)
+let assert Ok(Nil) = set.insert(table, "user:2", session_2)
+
+// Persist to disk when ready
+let assert Ok(Nil) = set.save(table)
+```
+
+**Best for**: High-throughput writes where you can tolerate some data loss on crash.
+
+:::caution[Data loss on crash]
+In WriteBack mode, data written since the last `save()` is lost if the process crashes. Design your save schedule based on your durability needs — e.g., periodic timer, after every N writes, or at clean shutdown.
+:::
+
+### Discarding Unsaved Changes
+
+Use `reload()` to discard unsaved ETS changes and restore from the last DETS snapshot:
+
+```gleam
+let assert Ok(Nil) = set.insert(table, "temp", "data")
+// Changed our mind — discard unsaved changes
+let assert Ok(Nil) = set.reload(table)
+// "temp" key no longer exists
+```
+
+## WriteThrough
+
+In WriteThrough mode, every write persists to both ETS and DETS immediately. Reads are still served from ETS (fast).
+
+```gleam
+import shelf
+import shelf/set
+
+let config =
+  shelf.config(name: "accounts", path: "data/accounts.dets")
+  |> shelf.write_mode(shelf.WriteThrough)
+
+let assert Ok(table) = set.open_config(config)
+
+// This writes to both ETS and DETS
+let assert Ok(Nil) = set.insert(table, "acct:1", account)
+```
+
+**Best for**: Data that must survive crashes with no loss — financial records, user accounts, configuration.
+
+### Guaranteeing Durability
+
+DETS buffers writes internally for performance. After a WriteThrough write, the data is in DETS but may still be in the OS write buffer. Use `sync()` to force the DETS buffer to the filesystem:
+
+```gleam
+let assert Ok(Nil) = set.insert(table, "critical", value)
+let assert Ok(Nil) = set.sync(table)
+// Data is now on disk
+```
+
+## Comparison
+
+| | WriteBack | WriteThrough |
+|---|-----------|-------------|
+| Write speed | Fast (ETS only) | Slower (ETS + DETS) |
+| Data loss on crash | Since last `save()` | None (after `sync()`) |
+| When to persist | Manual `save()` call | Automatic on every write |
+| `reload()` useful? | Yes — discards unsaved changes | Not typically — ETS and DETS are in sync |
+| Best for | Caches, sessions, high-throughput | Accounts, config, audit logs |
+
+## Setting Write Mode
+
+Write mode is set at table creation via `Config`:
+
+```gleam
+import shelf
+
+// WriteBack (the default — no config needed)
+let assert Ok(table) = set.open(name: "cache", path: "data/cache.dets")
+
+// WriteThrough (use config)
+let config =
+  shelf.config(name: "accounts", path: "data/accounts.dets")
+  |> shelf.write_mode(shelf.WriteThrough)
+let assert Ok(table) = set.open_config(config)
+```
+
+Write mode applies to all table types — `set`, `bag`, and `duplicate_bag` all support both modes.


### PR DESCRIPTION
## Summary

Comprehensive documentation review identified critical gaps (empty website pages, missing error/API docs) and important gaps (missing `member` docs, bare Result calls, inconsistent examples). This PR fixes all critical and important issues directly.

## Changes

### README (8 improvements)
- Fix bare `Result` calls in WriteBack/WriteThrough examples (`set.insert(...)` → `let assert Ok(Nil) = set.insert(...)`)
- Add **API comparison table** showing which operations are available per table type (set vs bag vs duplicate_bag)
- Add `member` function to set example
- Add **Error Handling** section documenting all 7 `ShelfError` variants with an example
- Add `save` vs `sync` clarification
- Add crash behavior warning for WriteBack mode
- Explain `PSet`/`PBag`/`PDuplicateBag` naming (P = Persistent)
- Remove redundant "Target" section (already covered in Limitations)

### Source doc comments (4 files)
- Fix positional arguments → labelled arguments in module-level examples across `shelf.gleam`, `set.gleam`, `bag.gleam`, and `duplicate_bag.gleam`

### Website — fill all 6 stub pages
Previously, 6 of 10 website pages were `TODO` stubs, creating dead-end links from the Quick Start "Next steps" section.

- **Set Tables** — all operations with examples (insert, insert_new, lookup, member, delete, fold, counters, with_table)
- **Bag Tables** — bag-specific guide with set vs bag comparison table
- **Duplicate Bag Tables** — duplicate bag guide with bag vs duplicate_bag comparison
- **Write Modes** — WriteBack vs WriteThrough with comparison table, durability guidance
- **Persistence Operations** — save/reload/sync/close with flow diagram
- **Limitations** — 2GB limit, no ordered set, Erlang only, single node, naming, process ownership, error reference

## Follow-up issues filed
- #4 — Add README examples for fold, delete, insert_list, size, to_list
- #5 — Document ETS process ownership and crash behavior in README/hex docs
- #6 — Enrich bag/duplicate_bag doc comments to match set module quality

## Validation
- `gleam check` ✅
- `gleam test` — all 33 tests pass ✅