### PR TITLE
fix: with_table shared helper, preserve panic detail, fix cleanup errors

### DIFF
--- a/.changes/unreleased/Fixed-20260408-153846.yaml
+++ b/.changes/unreleased/Fixed-20260408-153846.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: with_table now preserves panic crash detail instead of returning generic 'Callback panicked'; cleanup/3 no longer swallows all errors; with_table extracted to shared helper eliminating duplication across set/bag/duplicate_bag
+time: 2026-04-08T15:38:46.680077-07:00

--- a/src/shelf/bag.gleam
+++ b/src/shelf/bag.gleam
@@ -129,29 +129,20 @@ pub fn with_table(
   value value_decoder: Decoder(v),
   fun fun: fn(PBag(k, v)) -> Result(a, ShelfError),
 ) -> Result(a, ShelfError) {
-  use table <- result.try(open(
-    name:,
-    path:,
-    base_directory:,
-    key: key_decoder,
-    value: value_decoder,
-  ))
-  let result = case rescue(fn() { fun(table) }) {
-    Ok(result) -> result
-    Error(_crash) -> Error(shelf.ErlangError("Callback panicked"))
-  }
-  case close(table) {
-    Ok(Nil) -> result
-    Error(close_err) ->
-      case result {
-        Ok(_) -> Error(close_err)
-        Error(_) -> result
-      }
-  }
+  internal.generic_with_table(
+    fn() {
+      open(
+        name:,
+        path:,
+        base_directory:,
+        key: key_decoder,
+        value: value_decoder,
+      )
+    },
+    close,
+    fun,
+  )
 }
-
-@external(erlang, "shelf_rescue_ffi", "rescue")
-fn rescue(fun: fn() -> a) -> Result(a, String)
 
 // ── Read ────────────────────────────────────────────────────────────────
 

--- a/src/shelf/duplicate_bag.gleam
+++ b/src/shelf/duplicate_bag.gleam
@@ -129,29 +129,20 @@ pub fn with_table(
   value value_decoder: Decoder(v),
   fun fun: fn(PDuplicateBag(k, v)) -> Result(a, ShelfError),
 ) -> Result(a, ShelfError) {
-  use table <- result.try(open(
-    name:,
-    path:,
-    base_directory:,
-    key: key_decoder,
-    value: value_decoder,
-  ))
-  let result = case rescue(fn() { fun(table) }) {
-    Ok(result) -> result
-    Error(_crash) -> Error(shelf.ErlangError("Callback panicked"))
-  }
-  case close(table) {
-    Ok(Nil) -> result
-    Error(close_err) ->
-      case result {
-        Ok(_) -> Error(close_err)
-        Error(_) -> result
-      }
-  }
+  internal.generic_with_table(
+    fn() {
+      open(
+        name:,
+        path:,
+        base_directory:,
+        key: key_decoder,
+        value: value_decoder,
+      )
+    },
+    close,
+    fun,
+  )
 }
-
-@external(erlang, "shelf_rescue_ffi", "rescue")
-fn rescue(fun: fn() -> a) -> Result(a, String)
 
 // ── Read ────────────────────────────────────────────────────────────────
 

--- a/src/shelf/internal.gleam
+++ b/src/shelf/internal.gleam
@@ -195,6 +195,32 @@ pub fn generic_reload(
   stream_validate_and_load(ets, dets, entry_decoder, decode_policy)
 }
 
+/// Shared with_table implementation: open, run callback (with panic rescue),
+/// then close. Preserves crash detail from the rescue FFI.
+@internal
+pub fn generic_with_table(
+  open_fn: fn() -> Result(table, ShelfError),
+  close_fn: fn(table) -> Result(Nil, ShelfError),
+  fun: fn(table) -> Result(a, ShelfError),
+) -> Result(a, ShelfError) {
+  use table <- result.try(open_fn())
+  let callback_result = case rescue(fn() { fun(table) }) {
+    Ok(result) -> result
+    Error(crash_detail) -> Error(shelf.ErlangError(crash_detail))
+  }
+  case close_fn(table) {
+    Ok(Nil) -> callback_result
+    Error(close_err) ->
+      case callback_result {
+        Ok(_) -> Error(close_err)
+        Error(_) -> callback_result
+      }
+  }
+}
+
+@external(erlang, "shelf_rescue_ffi", "rescue")
+pub fn rescue(fun: fn() -> a) -> Result(a, String)
+
 /// Generic fold with key-value destructuring.
 @internal
 pub fn generic_fold(

--- a/src/shelf/set.gleam
+++ b/src/shelf/set.gleam
@@ -141,29 +141,20 @@ pub fn with_table(
   value value_decoder: Decoder(v),
   fun fun: fn(PSet(k, v)) -> Result(a, ShelfError),
 ) -> Result(a, ShelfError) {
-  use table <- result.try(open(
-    name:,
-    path:,
-    base_directory:,
-    key: key_decoder,
-    value: value_decoder,
-  ))
-  let result = case rescue(fn() { fun(table) }) {
-    Ok(result) -> result
-    Error(_crash) -> Error(shelf.ErlangError("Callback panicked"))
-  }
-  case close(table) {
-    Ok(Nil) -> result
-    Error(close_err) ->
-      case result {
-        Ok(_) -> Error(close_err)
-        Error(_) -> result
-      }
-  }
+  internal.generic_with_table(
+    fn() {
+      open(
+        name:,
+        path:,
+        base_directory:,
+        key: key_decoder,
+        value: value_decoder,
+      )
+    },
+    close,
+    fun,
+  )
 }
-
-@external(erlang, "shelf_rescue_ffi", "rescue")
-fn rescue(fun: fn() -> a) -> Result(a, String)
 
 // ── Read (always from ETS — fast) ───────────────────────────────────────
 

--- a/src/shelf_ffi.erl
+++ b/src/shelf_ffi.erl
@@ -228,15 +228,18 @@ stop_guardian(Guardian) ->
 %% Delete ETS table and close DETS without saving. Used on validation failure.
 
 cleanup(Ets, Dets, Guardian) ->
-    try
-        stop_guardian(Guardian),
-        Path = dets_to_path(Dets),
-        _ = dets:close(Dets),
-        _ = ets:delete(Ets),
-        unregister_dets_name(Path),
-        {ok, nil}
-    catch
-        _:_ -> {ok, nil}
+    stop_guardian(Guardian),
+    Path = try dets_to_path(Dets) catch _:_ -> undefined end,
+    DetsResult = (catch dets:close(Dets)),
+    _ = (catch ets:delete(Ets)),
+    case Path of
+        undefined -> ok;
+        _ -> unregister_dets_name(Path)
+    end,
+    case DetsResult of
+        ok -> {ok, nil};
+        {error, Reason} -> {error, translate_error(Reason)};
+        _ -> {ok, nil}
     end.
 
 %% ── Close ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Closes #32. Closes #39.

Three related with_table/cleanup issues fixed in one PR:

## Changes
1. **Extract `generic_with_table` to `internal.gleam`** — eliminates identical with_table implementations across set, bag, and duplicate_bag (was ~30 lines each, now delegates to shared helper)
2. **Preserve crash detail** — `rescue` FFI captures `Class:Reason` as a formatted string, but it was discarded with `Error(_crash) -> Error(shelf.ErlangError("Callback panicked"))`. Now passes through: `Error(crash_detail) -> Error(shelf.ErlangError(crash_detail))`
3. **Fix `cleanup/3`** — removed blanket `catch _:_ -> {ok, nil}` that swallowed all errors. Now reports DETS close failures while still best-effort cleaning up ETS.
4. **Single `rescue` FFI** — moved from 3 copies (set/bag/duplicate_bag) to one in `internal.gleam`, backed by `shelf_rescue_ffi.erl`

## Test plan
- [x] `gleam test` — all tests pass (existing panic safety + error handling tests still pass)
- [x] `gleam format --check src test`