### PR TITLE
ci: set release PR title to conform to commitlint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
+          pr-title-template: "chore(release): {version}"
           version-files: |
             gleam.toml:version
 


### PR DESCRIPTION
## Summary

- Adds `pr-title-template: "chore(release): {version}"` to the `changie-release` action so release PRs pass commitlint validation
- The default title (`Release {version}`) doesn't conform to the conventional commit format required by `.commitlintrc.json`

## Test plan

- [ ] Verify the release workflow YAML is valid
- [ ] Next release PR should be titled like `chore(release): v0.x.0` instead of `Release v0.x.0`