### PR TITLE
docs: fix inaccuracies in documentation

### DIFF
--- a/.claude/agents/shelf-otp-expert.md
+++ b/.claude/agents/shelf-otp-expert.md
@@ -17,7 +17,7 @@ Operating principles:
 - Respect shelf constraints: result-based errors, exhaustive pattern matching, and explicit error translation.
 - Preserve type-safe table handle boundaries (`PSet`, `PBag`, `PDuplicateBag`) and avoid API drift across modules.
 - Account for DETS limitations (disk IO, file limits, repair behavior, table close semantics).
-- Understand the two write modes: WriteBack (ETS-only writes, manual save) and WriteThrough (every write triggers `ets:to_dets` immediately).
+- Understand the two write modes: WriteBack (ETS-only writes, manual save) and WriteThrough (every write goes to DETS first via `dets:insert`, then ETS — `ets:to_dets/2` is only used by `save()`).
 
 When proposing changes:
 - Provide concrete code-level recommendations, not generic advice.

--- a/.claude/agents/shelf-otp-performance-expert.md
+++ b/.claude/agents/shelf-otp-performance-expert.md
@@ -13,13 +13,13 @@ Repository context:
 - shelf provides persistent ETS tables backed by DETS via Gleam modules in `src/shelf/{set,bag,duplicate_bag}.gleam`.
 - Shared types live in `src/shelf.gleam` with internal types in `src/shelf/internal.gleam`.
 - FFI and low-level behavior live in `src/shelf_ffi.erl`, wrapping `ets:*` and `dets:*` calls.
-- Two write modes: WriteBack (ETS-only, batch save) and WriteThrough (`ets:to_dets` on every write).
+- Two write modes: WriteBack (ETS-only, batch save) and WriteThrough (`dets:insert` + `ets:insert` on every write; `ets:to_dets/2` is only used by `save()`).
 
 Performance strategy:
 - Prefer OTP-native architectures: supervised workers, clear process ownership, bounded mailboxes, and failure isolation.
 - Model read/write paths explicitly; identify hot keys, fan-out, contention points, and IO bottlenecks.
 - Reads always come from ETS (microsecond latency); writes depend on the configured WriteMode.
-- WriteThrough uses `ets:to_dets/2` per write — profile and optimize this path for throughput-sensitive use cases.
+- WriteThrough uses `dets:insert` + `ets:insert` per write (DETS first for consistency) — profile and optimize this path for throughput-sensitive use cases.
 - WriteBack batches persistence via explicit `save()` calls — optimize batch size and timing.
 
 Rules for recommendations:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,9 @@ gleam docs build         # Generate documentation
 src/
 ├── shelf.gleam                 # Shared types (ShelfError, WriteMode, Config)
 ├── shelf_ffi.erl               # Erlang FFI for ETS + DETS + transfers
+├── shelf_rescue_ffi.erl        # Erlang FFI for panic rescue in with_table
 └── shelf/
-    ├── internal.gleam          # Internal types (EtsRef, DetsRef)
+    ├── internal.gleam          # Internal types (EtsRef, DetsRef) + shared operations
     ├── set.gleam               # Persistent set tables (unique keys)
     ├── bag.gleam               # Persistent bag tables (multiple values per key)
     └── duplicate_bag.gleam     # Persistent duplicate bag tables
@@ -31,7 +32,20 @@ test/
 ├── bag_test.gleam              # Bag table tests
 ├── duplicate_bag_test.gleam    # Duplicate bag table tests
 ├── persistence_test.gleam      # Save/reload/survive-restart tests
-└── write_through_test.gleam    # WriteThrough mode tests
+├── write_through_test.gleam    # WriteThrough mode tests
+├── writethrough_consistency_test.gleam  # WriteThrough DETS-first ordering tests
+├── ownership_test.gleam        # Process ownership + NotOwner tests
+├── concurrency_test.gleam      # Cross-process read tests
+├── guardian_test.gleam         # Guardian process cleanup tests
+├── atomic_save_test.gleam      # Atomic save (temp file + rename) tests
+├── reload_atomicity_test.gleam # Atomic reload (scratch table swap) tests
+├── close_test.gleam            # Close lifecycle + error recovery tests
+├── update_counter_test.gleam   # Atomic counter tests
+├── path_validation_test.gleam  # Path traversal / security tests
+├── type_safety_test.gleam      # Decoder validation tests
+├── error_handling_test.gleam   # ShelfError translation tests
+├── error_path_test.gleam       # Error path coverage tests
+└── ffi_fixes_test.gleam        # FFI edge case regression tests
 ```
 
 ## Architecture
@@ -47,7 +61,7 @@ test/
 ### Write Modes
 
 - **WriteBack** (default): Writes go to ETS only. Call `save()` to persist.
-- **WriteThrough**: Every write triggers `ets:to_dets/2` immediately.
+- **WriteThrough**: Every write goes to DETS first (via `dets:insert`), then ETS. Ensures DETS failure never leaves ETS in a divergent state.
 
 ### FFI Pattern
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,6 @@
 
 Persistent ETS tables backed by DETS — fast in-memory access with automatic disk persistence for the BEAM.
 
-> [!IMPORTANT]
-> shelf is not yet 1.0. This means:
->
-> - the API is unstable
-> - features and APIs may be removed in minor releases
-> - quality should not be considered production-ready
->
-> We welcome usage and feedback in
-> the meantime! We will do our best to minimize breaking changes regardless.
-
 Shelf combines ETS (fast, in-memory) with DETS (persistent, on-disk) to give you microsecond reads with durable storage. It implements the classic Erlang persistence pattern, wrapped in a type-safe Gleam API.
 
 If you only need ETS or DETS individually, check out these excellent standalone wrappers:

--- a/README.md
+++ b/README.md
@@ -244,11 +244,12 @@ All operations return `Result(value, ShelfError)`. The error type covers all fai
 | `NotFound` | Key doesn't exist (from `lookup`) |
 | `KeyAlreadyPresent` | Key exists (from `insert_new`) |
 | `TableClosed` | Table has been closed or doesn't exist |
-| `NameConflict` | An ETS table or DETS file is already open with conflicting parameters |
+| `NotOwner` | The calling process is not the table owner (see [Process Ownership](#process-ownership)) |
+| `NameConflict` | A DETS file at this path is already open by another shelf table |
 | `InvalidPath(String)` | File path escapes the base directory or contains unsafe characters |
 | `FileError(String)` | DETS file couldn't be found, created, or opened |
 | `FileSizeLimitExceeded` | DETS file exceeds the 2 GB limit |
-| `TypeMismatch` | Data loaded from DETS failed decoder validation |
+| `TypeMismatch(List(DecodeError))` | Data loaded from DETS failed decoder validation |
 | `ErlangError(String)` | Catch-all for unexpected Erlang-level errors |
 
 ```gleam
@@ -257,8 +258,8 @@ case set.open(name: "cache", path: "data/cache.dets",
   key: decode.string, value: decode.string)
 {
   Ok(table) -> use_table(table)
-  Error(shelf.TypeMismatch) -> io.println("DETS data doesn't match expected types!")
-  Error(shelf.NameConflict) -> io.println("Table already open!")
+  Error(shelf.TypeMismatch(_errors)) -> io.println("DETS data doesn't match expected types!")
+  Error(shelf.NameConflict) -> io.println("DETS file already open!")
   Error(shelf.InvalidPath(msg)) -> io.println("Invalid path: " <> msg)
   Error(shelf.FileError(msg)) -> io.println("File error: " <> msg)
   Error(err) -> io.println("Unexpected: " <> string.inspect(err))
@@ -339,23 +340,29 @@ let assert Ok(entries) = set.to_list(from: t)
 
 All DETS file paths are validated against the provided `base_directory` to prevent path traversal attacks. Paths containing `..` segments or other unsafe patterns that would escape the base directory are rejected with an `InvalidPath` error.
 
-## Concurrency
+## Process Ownership
 
-ETS tables support concurrent reads from any process. Write safety depends on the table type:
+ETS tables are owned by the process that calls `open()`. This determines what each process can do:
 
-- **Set tables**: Concurrent writes to *different* keys are safe. Concurrent writes to the *same* key result in last-writer-wins (no corruption, but potential data loss).
-- **Bag / Duplicate Bag**: Same concurrency model as set — concurrent writes to different keys are safe.
+- **Reads** (`lookup`, `member`, `to_list`, `fold`, `size`) work from **any** process — ETS tables are created as `protected`.
+- **Writes and lifecycle** (`insert`, `delete_*`, `update_counter`, `save`, `reload`, `sync`, `close`) are restricted to the **owner** process. Non-owner attempts return `Error(NotOwner)`.
 
-All shelf operations are individual ETS/DETS calls — there is no built-in transaction support. If you need atomic multi-key updates, coordinate through a single process (e.g., a GenServer).
+If you need cross-process writes, wrap the table in a supervised actor/server that owns the table and forwards mutation requests.
 
-### Process Supervision
+### Crash Behavior
 
-ETS tables are owned by the process that creates them. If the owning process crashes, the ETS table is deleted and unsaved data is lost. The DETS file is preserved.
+If the owning process crashes, the ETS table is deleted and unsaved data is lost. The DETS file is preserved — the next `open()` call reloads it.
 
 For long-running applications:
 - Open tables in a supervised process (e.g., an OTP GenServer or Gleam actor)
 - Consider periodic `save()` calls for WriteBack mode
 - Use WriteThrough mode for data that cannot tolerate loss
+
+### Write Safety
+
+Within the owner process, all shelf operations are individual ETS/DETS calls — there is no built-in transaction support. If you need atomic multi-key updates, coordinate through a single process (e.g., a GenServer).
+
+For set tables, concurrent reads from other processes while the owner writes to *different* keys are safe. Writes to the *same* key result in last-writer-wins (no corruption, but potential data loss from the reader's perspective). Bag and duplicate bag tables follow the same model.
 
 ## See Also
 

--- a/src/shelf/bag.gleam
+++ b/src/shelf/bag.gleam
@@ -17,6 +17,7 @@
 ///
 /// let assert Ok(table) =
 ///   bag.open(name: "tags", path: "data/tags.dets",
+///     base_directory: "/app/data",
 ///     key: decode.string, value: decode.string)
 /// let assert Ok(Nil) = bag.insert(table, "color", "red")
 /// let assert Ok(Nil) = bag.insert(table, "color", "blue")

--- a/src/shelf/duplicate_bag.gleam
+++ b/src/shelf/duplicate_bag.gleam
@@ -17,6 +17,7 @@
 ///
 /// let assert Ok(table) =
 ///   duplicate_bag.open(name: "events", path: "data/events.dets",
+///     base_directory: "/app/data",
 ///     key: decode.string, value: decode.string)
 /// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "btn_1")
 /// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "btn_1")


### PR DESCRIPTION
## Summary

- Remove API stability warning from README
- Fix README error table: add missing `NotOwner` error, correct `TypeMismatch` parameter, fix `NameConflict` description
- Replace misleading Concurrency section with Process Ownership section that correctly describes protected ETS tables (reads from any process, writes owner-only)
- Fix WriteThrough description in CLAUDE.md and both agent docs: it uses `dets:insert` + `ets:insert` per write, not `ets:to_dets/2` (which is only used by `save()`)
- Update CLAUDE.md project structure: add `shelf_rescue_ffi.erl` and 13 missing test files
- Add missing `base_directory` parameter to module doc examples in `bag.gleam` and `duplicate_bag.gleam`

## Test plan

- [x] `gleam check` passes
- Documentation-only changes; no behavior change