### PR TITLE
docs: sync website docs with current API and behavior

### DIFF
--- a/website/src/content/docs/advanced/limitations.md
+++ b/website/src/content/docs/advanced/limitations.md
@@ -32,29 +32,37 @@ DETS is local to one Erlang node. Data is not replicated or distributed. For mul
 - **Mnesia** — Built-in distributed database for Erlang
 - **Raft-based solutions** — For consensus-based replication
 
-## Table Names Must Be Unique
+## DETS File Paths Must Be Unique
 
-ETS table names are VM-global atoms. If you try to open a table with a name that's already in use by another ETS table (from shelf or any other library), you'll get `Error(NameConflict)`.
+Shelf uses unnamed ETS tables internally, so table names do not need to be globally unique. However, each DETS file path can only be open by one shelf table at a time. Opening a second table with the same resolved file path returns `Error(NameConflict)`.
 
-Use descriptive, namespaced names to avoid collisions:
+Use distinct file paths for each table:
 
 ```gleam
-// Good — namespaced
-set.open(name: "myapp_user_sessions", path: "data/sessions.dets", key: decode.string, value: decode.string)
+// These are fine — different file paths
+set.open(name: "sessions", path: "sessions.dets", base_directory: "/app/data", key: decode.string, value: decode.string)
+set.open(name: "cache", path: "cache.dets", base_directory: "/app/data", key: decode.string, value: decode.string)
 
-// Risky — generic name might collide
-set.open(name: "cache", path: "data/cache.dets", key: decode.string, value: decode.string)
+// This would conflict if "sessions.dets" is already open
+set.open(name: "other_sessions", path: "sessions.dets", base_directory: "/app/data", key: decode.string, value: decode.string)
 ```
 
 ## Process Ownership
 
-ETS tables are owned by the process that created them. If that process crashes or exits, the ETS table is automatically deleted — any unsaved data is lost. The DETS file on disk remains intact.
+ETS tables are owned by the process that calls `open()`. Shelf creates ETS tables as `protected`, which determines what each process can do:
 
-When the application restarts and calls `open()` again, data is reloaded from the DETS file.
+- **Reads** (`lookup`, `member`, `to_list`, `fold`, `size`) work from **any** process.
+- **Writes and lifecycle** (`insert`, `delete_*`, `update_counter`, `save`, `reload`, `sync`, `close`) are restricted to the **owner** process. Non-owner attempts return `Error(NotOwner)`.
+
+If you need cross-process writes, wrap the table in a supervised actor/server that owns the table and forwards mutation requests.
+
+### Crash Behavior
+
+If the owning process crashes or exits, the ETS table is automatically deleted — any unsaved data is lost. The DETS file on disk remains intact. When the application restarts and calls `open()` again, data is reloaded from the DETS file.
 
 To mitigate this:
 - Use `with_table` for short-lived operations
-- In long-running applications, ensure the process that opens tables is supervised
+- In long-running applications, open tables in a supervised process (e.g., an OTP GenServer or Gleam actor)
 - Use WriteThrough mode for critical data to minimize the window of potential data loss
 
 ## Error Handling
@@ -65,9 +73,11 @@ All shelf operations return `Result(value, ShelfError)`. The error variants are:
 |-------|-------|
 | `NotFound` | Key doesn't exist (from `lookup`) |
 | `KeyAlreadyPresent` | Key exists (from `insert_new`, set tables only) |
-| `TypeMismatch` | Data loaded from disk didn't match the expected decoder types |
 | `TableClosed` | Table has been closed or doesn't exist |
-| `NameConflict` | An ETS table with this name is already open |
+| `NotOwner` | The calling process is not the table owner (see Process Ownership above) |
+| `NameConflict` | A DETS file at this path is already open by another shelf table |
+| `InvalidPath(String)` | File path escapes the base directory or contains unsafe characters |
 | `FileError(String)` | DETS file couldn't be found, created, or opened |
 | `FileSizeLimitExceeded` | DETS file exceeds the 2 GB limit |
+| `TypeMismatch(List(DecodeError))` | Data loaded from DETS failed decoder validation |
 | `ErlangError(String)` | Catch-all for unexpected Erlang-level errors |

--- a/website/src/content/docs/advanced/persistence-operations.md
+++ b/website/src/content/docs/advanced/persistence-operations.md
@@ -29,7 +29,7 @@ let assert Ok(Nil) = set.save(table)
 - At application shutdown
 - After critical data changes
 
-In WriteThrough mode, `save()` is called automatically after every write, so you rarely need to call it manually.
+In WriteThrough mode, every write goes to DETS directly (via `dets:insert`), so data is already persisted — you rarely need to call `save()` manually.
 
 ## reload
 
@@ -71,7 +71,7 @@ For guaranteed cleanup, use `with_table` instead of manual open/close:
 
 ```gleam
 let assert Ok(Nil) = {
-  use table <- set.with_table("cache", "data/cache.dets", decode.string, decode.string)
+  use table <- set.with_table("cache", "data/cache.dets", base_directory: "/app/data", key: decode.string, value: decode.string)
   set.insert(into: table, key: "key", value: "value")
 }
 // table is automatically closed here
@@ -89,8 +89,8 @@ flowchart LR
   end
   subgraph wt["WriteThrough mode"]
     direction LR
-    I2[insert] -->|write| E2[ETS]
-    E2 -->|"auto save()"| D2[DETS]
+    I2[insert] -->|"dets:insert"| D2[DETS]
+    I2 -->|"ets:insert"| E2[ETS]
     D2 -->|"sync()"| F2[filesystem]
   end
 ```

--- a/website/src/content/docs/guides/bag-tables.md
+++ b/website/src/content/docs/guides/bag-tables.md
@@ -12,7 +12,7 @@ import gleam/dynamic/decode
 import shelf/bag
 
 let assert Ok(table) =
-  bag.open(name: "tags", path: "data/tags.dets", key: decode.string, value: decode.string)
+  bag.open(name: "tags", path: "data/tags.dets", base_directory: "/app/data", key: decode.string, value: decode.string)
 ```
 
 For custom configuration, use `open_config`:
@@ -23,7 +23,7 @@ import shelf
 import shelf/bag
 
 let config =
-  shelf.config(name: "tags", path: "data/tags.dets")
+  shelf.config(name: "tags", path: "data/tags.dets", base_directory: "/app/data")
   |> shelf.write_mode(shelf.WriteThrough)
 
 let assert Ok(table) = bag.open_config(config: config, key: decode.string, value: decode.string)

--- a/website/src/content/docs/guides/set-tables.md
+++ b/website/src/content/docs/guides/set-tables.md
@@ -12,7 +12,7 @@ import gleam/dynamic/decode
 import shelf/set
 
 let assert Ok(table) =
-  set.open(name: "users", path: "data/users.dets", key: decode.string, value: decode.int)
+  set.open(name: "users", path: "data/users.dets", base_directory: "/app/data", key: decode.string, value: decode.int)
 ```
 
 If the DETS file exists, its contents are loaded into ETS automatically. If the file doesn't exist, both tables start empty.
@@ -25,7 +25,7 @@ import shelf
 import shelf/set
 
 let config =
-  shelf.config(name: "users", path: "data/users.dets")
+  shelf.config(name: "users", path: "data/users.dets", base_directory: "/app/data")
   |> shelf.write_mode(shelf.WriteThrough)
 
 let assert Ok(table) = set.open_config(config: config, key: decode.string, value: decode.int)
@@ -112,7 +112,7 @@ Use `with_table` to ensure a table is always closed, even if an error occurs:
 
 ```gleam
 let assert Ok(Nil) = {
-  use table <- set.with_table("cache", "data/cache.dets", decode.string, decode.string)
+  use table <- set.with_table("cache", "data/cache.dets", base_directory: "/app/data", key: decode.string, value: decode.string)
   set.insert(into: table, key: "key", value: "value")
 }
 ```

--- a/website/src/content/docs/guides/write-modes.md
+++ b/website/src/content/docs/guides/write-modes.md
@@ -14,7 +14,7 @@ import gleam/dynamic/decode
 import shelf/set
 
 let assert Ok(table) =
-  set.open(name: "sessions", path: "data/sessions.dets", key: decode.string, value: decode.string)
+  set.open(name: "sessions", path: "data/sessions.dets", base_directory: "/app/data", key: decode.string, value: decode.string)
 
 // Fast writes — ETS only
 let assert Ok(Nil) = set.insert(table, "user:1", session_1)
@@ -51,7 +51,7 @@ import shelf
 import shelf/set
 
 let config =
-  shelf.config(name: "accounts", path: "data/accounts.dets")
+  shelf.config(name: "accounts", path: "data/accounts.dets", base_directory: "/app/data")
   |> shelf.write_mode(shelf.WriteThrough)
 
 let assert Ok(table) = set.open_config(config: config, key: decode.string, value: decode.string)
@@ -92,11 +92,11 @@ import shelf
 
 // WriteBack (the default — no config needed)
 let assert Ok(table) =
-  set.open(name: "cache", path: "data/cache.dets", key: decode.string, value: decode.string)
+  set.open(name: "cache", path: "data/cache.dets", base_directory: "/app/data", key: decode.string, value: decode.string)
 
 // WriteThrough (use config)
 let config =
-  shelf.config(name: "accounts", path: "data/accounts.dets")
+  shelf.config(name: "accounts", path: "data/accounts.dets", base_directory: "/app/data")
   |> shelf.write_mode(shelf.WriteThrough)
 let assert Ok(table) =
   set.open_config(config: config, key: decode.string, value: decode.string)

--- a/website/src/content/docs/quick-start.md
+++ b/website/src/content/docs/quick-start.md
@@ -24,7 +24,7 @@ import shelf/set
 pub fn main() {
   // Open a persistent set — loads existing data from disk
   let assert Ok(table) =
-    set.open(name: "users", path: "data/users.dets", key: decode.string, value: decode.int)
+    set.open(name: "users", path: "data/users.dets", base_directory: "/app/data", key: decode.string, value: decode.int)
 
   // Fast writes (to ETS)
   let assert Ok(Nil) = set.insert(table, "alice", 42)


### PR DESCRIPTION
## Summary

Closes #37

- Add missing `base_directory` parameter to all `open()`, `config()`, and `with_table()` calls in set-tables, bag-tables, write-modes, quick-start, and persistence-operations guides
- Fix WriteThrough description in persistence-operations.md: writes use `dets:insert` directly, not `save()`; fix mermaid diagram to show DETS-first write ordering
- Replace stale "Table Names Must Be Unique" section in limitations.md with "DETS File Paths Must Be Unique" (shelf uses unnamed ETS tables)
- Rewrite Process Ownership section to document `protected` ETS, owner-only writes, and `NotOwner` error
- Update error table: add `NotOwner` and `InvalidPath`, fix `NameConflict` description, show `TypeMismatch(List(DecodeError))`

## Test plan

- [x] `gleam check` passes
- [x] `gleam test` — 138 tests pass
- [x] `just check-examples` passes
- [ ] Visual review of website docs for accuracy