### PR TITLE
docs: fix doc bugs and normalize voice

### DIFF
--- a/src/shelf.gleam
+++ b/src/shelf.gleam
@@ -1,6 +1,6 @@
 /// Persistent ETS tables backed by DETS.
 ///
-/// Shelf combines ETS (fast, in-memory) with DETS (persistent, on-disk)
+/// shelf combines ETS (fast, in-memory) with DETS (persistent, on-disk)
 /// to give you microsecond reads with durable storage. The classic
 /// Erlang persistence pattern, wrapped in a type-safe Gleam API.
 ///

--- a/src/shelf/bag.gleam
+++ b/src/shelf/bag.gleam
@@ -110,7 +110,7 @@ pub fn open(
 /// On `Ok(Nil)`, the handle must not be used again. If the final save
 /// fails with a retryable persistence error, `close()` returns
 /// `Error(...)` and leaves the table open so the caller can retry.
-/// If close fails terminally, Shelf still releases resources and future
+/// If close fails terminally, shelf still releases resources and future
 /// operations on the handle return `Error(TableClosed)`.
 ///
 pub fn close(table: PBag(k, v)) -> Result(Nil, ShelfError) {

--- a/src/shelf/duplicate_bag.gleam
+++ b/src/shelf/duplicate_bag.gleam
@@ -110,7 +110,7 @@ pub fn open(
 /// On `Ok(Nil)`, the handle must not be used again. If the final save
 /// fails with a retryable persistence error, `close()` returns
 /// `Error(...)` and leaves the table open so the caller can retry.
-/// If close fails terminally, Shelf still releases resources and future
+/// If close fails terminally, shelf still releases resources and future
 /// operations on the handle return `Error(TableClosed)`.
 ///
 pub fn close(table: PDuplicateBag(k, v)) -> Result(Nil, ShelfError) {

--- a/src/shelf/set.gleam
+++ b/src/shelf/set.gleam
@@ -118,7 +118,7 @@ pub fn open(
 /// On `Ok(Nil)`, the handle must not be used again. If the final save
 /// fails with a retryable persistence error, `close()` returns
 /// `Error(...)` and leaves the table open so the caller can retry.
-/// If close fails terminally, Shelf still releases resources and future
+/// If close fails terminally, shelf still releases resources and future
 /// operations on the handle return `Error(TableClosed)`.
 ///
 pub fn close(table: PSet(k, v)) -> Result(Nil, ShelfError) {

--- a/website/src/content/docs/advanced/limitations.md
+++ b/website/src/content/docs/advanced/limitations.md
@@ -34,7 +34,7 @@ DETS is local to one Erlang node. Data is not replicated or distributed. For mul
 
 ## DETS File Paths Must Be Unique
 
-Shelf uses unnamed ETS tables internally, so table names do not need to be globally unique. However, each DETS file path can only be open by one shelf table at a time. Opening a second table with the same resolved file path returns `Error(NameConflict)`.
+shelf uses unnamed ETS tables internally, so table names do not need to be globally unique. However, each DETS file path can only be open by one shelf table at a time. Opening a second table with the same resolved file path returns `Error(NameConflict)`.
 
 Use distinct file paths for each table:
 
@@ -49,7 +49,7 @@ set.open(name: "other_sessions", path: "sessions.dets", base_directory: "/app/da
 
 ## Process Ownership
 
-ETS tables are owned by the process that calls `open()`. Shelf creates ETS tables as `protected`, which determines what each process can do:
+ETS tables are owned by the process that calls `open()`. shelf creates ETS tables as `protected`, which determines what each process can do:
 
 - **Reads** (`lookup`, `member`, `to_list`, `fold`, `size`) work from **any** process.
 - **Writes and lifecycle** (`insert`, `delete_*`, `update_counter`, `save`, `reload`, `sync`, `close`) are restricted to the **owner** process. Non-owner attempts return `Error(NotOwner)`.

--- a/website/src/content/docs/advanced/persistence-operations.md
+++ b/website/src/content/docs/advanced/persistence-operations.md
@@ -9,14 +9,18 @@ shelf provides four persistence operations to control how and when data moves be
 
 | Function | Behavior |
 |----------|----------|
-| `save(table)` | Snapshot ETS → DETS (replaces DETS contents) |
+| `save(table)` | Atomic snapshot ETS → DETS (writes to a temp file, then renames for crash safety) |
 | `reload(table)` | Discard ETS, reload from DETS |
 | `sync(table)` | Flush DETS write buffer to OS |
 | `close(table)` | Save + close DETS + delete ETS |
 
 ## save
 
-Atomically snapshots the entire ETS table into DETS, replacing all DETS contents with the current ETS state. Uses `ets:to_dets/2` internally — the transfer happens efficiently inside the Erlang VM without materializing the table as a list.
+Atomically snapshots the entire ETS table into DETS, replacing all DETS contents with the current ETS state.
+
+The save uses a temp-file-plus-rename strategy for crash safety: data is written to a temporary file first, then atomically renamed over the original DETS file. If the process is killed mid-save, the original file remains intact until the rename succeeds.
+
+Internally, the ETS-to-DETS copy uses `ets:to_dets/2`, which transfers entries inside the Erlang VM without materializing the table as a list.
 
 ```gleam
 // After a batch of writes...

--- a/website/src/content/docs/guides/duplicate-bag-tables.md
+++ b/website/src/content/docs/guides/duplicate-bag-tables.md
@@ -15,6 +15,7 @@ let assert Ok(table) =
   duplicate_bag.open(
     name: "events",
     path: "data/events.dets",
+    base_directory: "/app/data",
     key: decode.string,
     value: decode.string,
   )
@@ -28,7 +29,7 @@ import shelf
 import shelf/duplicate_bag
 
 let config =
-  shelf.config(name: "events", path: "data/events.dets")
+  shelf.config(name: "events", path: "data/events.dets", base_directory: "/app/data")
   |> shelf.write_mode(shelf.WriteThrough)
 
 let assert Ok(table) =
@@ -91,7 +92,7 @@ Like bag tables, duplicate bag tables do **not** support `insert_new` or `update
 // Delete all values for a key
 let assert Ok(Nil) = duplicate_bag.delete_key(from: table, key: "click")
 
-// Delete a specific key-value pair (removes matching occurrences)
+// Delete every occurrence of this exact key-value pair
 let assert Ok(Nil) = duplicate_bag.delete_object(from: table, key: "hover", value: "menu")
 
 // Delete all entries

--- a/website/src/content/docs/guides/set-tables.md
+++ b/website/src/content/docs/guides/set-tables.md
@@ -84,7 +84,10 @@ let assert Ok(Nil) = set.insert_list(into: table, entries: [
 // Delete by key
 let assert Ok(Nil) = set.delete_key(from: table, key: "alice")
 
-// Delete a specific key-value pair (equivalent to delete_key for sets)
+// Compare-and-delete: only deletes if the stored value matches.
+// If "bob" is not currently 99, nothing is removed — useful for
+// optimistic concurrency where you want to avoid clobbering a
+// concurrent update.
 let assert Ok(Nil) = set.delete_object(from: table, key: "bob", value: 99)
 
 // Delete all entries (keeps the table open)

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: shelf
 description: Persistent ETS tables backed by DETS for Gleam.
 template: splash
 hero:
-  tagline: Fast in-memory access with automatic disk persistence for the BEAM, targeting the Erlang runtime.
+  tagline: Fast in-memory access with automatic disk persistence for the BEAM.
   image:
     file: ../../assets/shelf-logo.webp
     alt: shelf logo

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -41,4 +41,4 @@ shelf coordinates both together, using Erlang's native `ets:to_dets/2` for effic
 - **Three table types**: `set`, `bag`, `duplicate_bag`
 - **Atomic counters**: Increment integer values atomically in ETS
 - **Safe resource management**: `with_table` ensures tables are always closed
-- **Zero external dependencies**: Built entirely on OTP's ETS and DETS
+- **No native dependencies**: No NIFs or build steps; backed entirely by OTP's built-in ETS and DETS


### PR DESCRIPTION
Surgical fixes from a documentation review of the README, website, and inline docstrings. Each change addresses a concrete correctness or consistency issue.

## Bug fixes

- **`guides/duplicate-bag-tables.md`** — every `duplicate_bag.open()` and `shelf.config()` example was missing the required `base_directory:` argument. The snippets would not type-check.
- **`guides/set-tables.md`** — `delete_object` was described as 'equivalent to `delete_key` for sets'. The source (`src/shelf/set.gleam:271`) and README document it as **compare-and-delete** (only deletes when both key and value match). Corrected and added a note about the optimistic-concurrency use case.
- **`guides/duplicate-bag-tables.md`** — clarified that `delete_object` removes **every** occurrence of the exact key-value pair (matches `ets:delete_object` semantics).
- **`advanced/persistence-operations.md`** — added the temp-file-plus-rename atomic save guarantee that was already documented in the README and inline docstring but missing from the website. Updated the overview table to match.
- **`introduction.md`** — 'Zero external dependencies' was misleading; `gleam_stdlib` and `gleam_erlang` are listed in `installation.md`. Reworded to 'No native dependencies'.

## Polish

- **`index.mdx`** — dropped the redundant 'targeting the Erlang runtime' from the hero tagline (BEAM == Erlang runtime).
- **`limitations.md` and inline docstrings** — normalized 'Shelf' to 'shelf' to match the lowercase brand casing used everywhere else.

## Verification

- `gleam check` passes
- `gleam format` is clean

## Follow-up

Larger documentation issues from the same review (argument-style consistency, sync/save durability story, troubleshooting and recipes pages, splash card layout, schema-migration procedure, pre-1.0 caution deduplication) are tracked separately as issues.