### PR TITLE
docs: extract pre-1.0 caution into shared component

### DIFF
--- a/website/src/components/PreReleaseNotice.astro
+++ b/website/src/components/PreReleaseNotice.astro
@@ -1,0 +1,9 @@
+---
+import { Aside } from "@astrojs/starlight/components";
+---
+
+<Aside type="caution" title="Pre-1.0 Software">
+	shelf is not yet 1.0. The API is unstable, features may be removed
+	in minor releases, and quality should not be considered production-ready.
+	We welcome usage and feedback in the meantime!
+</Aside>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -17,11 +17,10 @@ hero:
       variant: secondary
 ---
 
-import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
+import { Card, CardGrid } from '@astrojs/starlight/components';
+import PreReleaseNotice from '../../components/PreReleaseNotice.astro';
 
-<Aside type="caution" title="Pre-1.0 Software">
-shelf is not yet 1.0. The API is unstable, features may be removed in minor releases, and quality should not be considered production-ready. We welcome usage and feedback in the meantime!
-</Aside>
+<PreReleaseNotice />
 
 ## Features
 

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -3,9 +3,9 @@ title: Installation
 description: How to install shelf in your Gleam project.
 ---
 
-:::caution[Pre-1.0 Software]
-shelf is not yet 1.0. The API is unstable and features may be removed in minor releases.
-:::
+import PreReleaseNotice from '../../components/PreReleaseNotice.astro';
+
+<PreReleaseNotice />
 
 Add shelf to your Gleam project:
 

--- a/website/src/content/docs/introduction.mdx
+++ b/website/src/content/docs/introduction.mdx
@@ -3,9 +3,9 @@ title: What is shelf?
 description: An introduction to shelf and persistent ETS tables.
 ---
 
-:::caution[Pre-1.0 Software]
-shelf is not yet 1.0. The API is unstable, features may be removed in minor releases, and quality should not be considered production-ready. We welcome usage and feedback in the meantime!
-:::
+import PreReleaseNotice from '../../components/PreReleaseNotice.astro';
+
+<PreReleaseNotice />
 
 shelf combines **ETS** (fast, in-memory) with **DETS** (persistent, on-disk) to give you microsecond reads with durable storage. It implements the classic Erlang persistence pattern, wrapped in a type-safe Gleam API.
 

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -3,9 +3,9 @@ title: Quick Start
 description: Get up and running with shelf in minutes.
 ---
 
-:::caution[Pre-1.0 Software]
-shelf is not yet 1.0. The API is unstable and features may be removed in minor releases.
-:::
+import PreReleaseNotice from '../../components/PreReleaseNotice.astro';
+
+<PreReleaseNotice />
 
 This guide walks you through basic persistent ETS operations with shelf.
 


### PR DESCRIPTION
Closes #57

The pre-1.0 caution block was duplicated verbatim (with minor wording drift) at the top of `index.mdx`, `introduction.md`, `installation.md`, and `quick-start.md`. This PR introduces a shared `PreReleaseNotice.astro` component and uses it on all four pages.

The three `.md` pages were renamed to `.mdx` so they can import the component (slugs unchanged).
