### PR TITLE
docs: use named arguments uniformly in examples

### DIFF
--- a/.changes/unreleased/Changed-20260424-192125.yaml
+++ b/.changes/unreleased/Changed-20260424-192125.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: |-
+    Use named arguments consistently in documentation examples (#62)
+    README examples, website guides, and public source docs now show the same named-argument call style for table operations so generated package docs match the recommended usage.
+time: 2026-04-24T19:21:25.752915-07:00

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ pub fn main() {
       key: decode.string, value: decode.int)
 
   // Fast writes (to ETS)
-  let assert Ok(Nil) = set.insert(table, "alice", 42)
-  let assert Ok(Nil) = set.insert(table, "bob", 99)
+  let assert Ok(Nil) = set.insert(into: table, key: "alice", value: 42)
+  let assert Ok(Nil) = set.insert(into: table, key: "bob", value: 99)
 
   // Fast reads (from ETS)
-  let assert Ok(42) = set.lookup(table, "alice")
+  let assert Ok(42) = set.lookup(from: table, key: "alice")
 
   // Persist to disk when ready
   let assert Ok(Nil) = set.save(table)
@@ -87,8 +87,8 @@ let assert Ok(table) =
     key: decode.string, value: session_decoder)
 
 // These are ETS-only (fast)
-let assert Ok(Nil) = set.insert(table, "user:123", session)
-let assert Ok(Nil) = set.insert(table, "user:456", session)
+let assert Ok(Nil) = set.insert(into: table, key: "user:123", value: session)
+let assert Ok(Nil) = set.insert(into: table, key: "user:456", value: session)
 
 // Persist when ready (e.g., on a timer, after N writes)
 let assert Ok(Nil) = set.save(table)
@@ -115,7 +115,7 @@ let assert Ok(table) =
     key: decode.string, value: account_decoder)
 
 // This writes to both ETS and DETS
-let assert Ok(Nil) = set.insert(table, "acct:789", account)
+let assert Ok(Nil) = set.insert(into: table, key: "acct:789", value: account)
 ```
 
 ## Table Types
@@ -132,9 +132,9 @@ let assert Ok(t) =
   set.open(name: "cache", path: "cache.dets",
     base_directory: "/app/data",
     key: decode.string, value: decode.string)
-let assert Ok(Nil) = set.insert(t, "key", "value")       // overwrites if exists
-let assert Error(shelf.KeyAlreadyPresent) = set.insert_new(t, "key", "value2")
-let assert Ok("value") = set.lookup(t, "key")
+let assert Ok(Nil) = set.insert(into: t, key: "key", value: "value")       // overwrites if exists
+let assert Error(shelf.KeyAlreadyPresent) = set.insert_new(into: t, key: "key", value: "value2")
+let assert Ok("value") = set.lookup(from: t, key: "key")
 let assert Ok(True) = set.member(of: t, key: "key")      // check existence
 ```
 
@@ -147,10 +147,10 @@ let assert Ok(t) =
   bag.open(name: "tags", path: "tags.dets",
     base_directory: "/app/data",
     key: decode.string, value: decode.string)
-let assert Ok(Nil) = bag.insert(t, "color", "red")
-let assert Ok(Nil) = bag.insert(t, "color", "blue")
-let assert Ok(Nil) = bag.insert(t, "color", "red")    // ignored (duplicate)
-let assert Ok(["red", "blue"]) = bag.lookup(t, "color")
+let assert Ok(Nil) = bag.insert(into: t, key: "color", value: "red")
+let assert Ok(Nil) = bag.insert(into: t, key: "color", value: "blue")
+let assert Ok(Nil) = bag.insert(into: t, key: "color", value: "red")    // ignored (duplicate)
+let assert Ok(["red", "blue"]) = bag.lookup(from: t, key: "color")
 ```
 
 ### Duplicate Bag — duplicates allowed
@@ -162,9 +162,9 @@ let assert Ok(t) =
   duplicate_bag.open(name: "events", path: "events.dets",
     base_directory: "/app/data",
     key: decode.string, value: decode.string)
-let assert Ok(Nil) = duplicate_bag.insert(t, "click", "btn")
-let assert Ok(Nil) = duplicate_bag.insert(t, "click", "btn")  // kept!
-let assert Ok(["btn", "btn"]) = duplicate_bag.lookup(t, "click")
+let assert Ok(Nil) = duplicate_bag.insert(into: t, key: "click", value: "btn")
+let assert Ok(Nil) = duplicate_bag.insert(into: t, key: "click", value: "btn")  // kept!
+let assert Ok(["btn", "btn"]) = duplicate_bag.lookup(from: t, key: "click")
 ```
 
 ### API Comparison
@@ -194,7 +194,7 @@ Use `with_table` to ensure tables are always closed:
 use table <- set.with_table("cache", "data/cache.dets",
   base_directory: "/app/data",
   key: decode.string, value: decode.string)
-set.insert(table, "key", "value")
+set.insert(into: table, key: "key", value: "value")
 // table is auto-closed when the callback returns
 ```
 
@@ -273,9 +273,9 @@ let assert Ok(t) =
   set.open(name: "stats", path: "stats.dets",
     base_directory: "/app/data",
     key: decode.string, value: decode.int)
-set.insert(t, "page_views", 0)
-set.update_counter(t, "page_views", 1)   // Ok(1)
-set.update_counter(t, "page_views", 10)  // Ok(11)
+set.insert(into: t, key: "page_views", value: 0)
+set.update_counter(in: t, key: "page_views", increment: 1)   // Ok(1)
+set.update_counter(in: t, key: "page_views", increment: 10)  // Ok(11)
 ```
 
 ## Common Operations

--- a/src/shelf.gleam
+++ b/src/shelf.gleam
@@ -15,8 +15,8 @@
 ///   set.open(name: "cache", path: "data/cache.dets",
 ///     base_directory: "/app/storage",
 ///     key: decode.string, value: decode.string)
-/// let assert Ok(Nil) = set.insert(table, "key", "value")
-/// let assert Ok("value") = set.lookup(table, "key")
+/// let assert Ok(Nil) = set.insert(into: table, key: "key", value: "value")
+/// let assert Ok("value") = set.lookup(from: table, key: "key")
 /// let assert Ok(Nil) = set.save(table)   // persist to disk
 /// let assert Ok(Nil) = set.close(table)
 /// ```

--- a/src/shelf/bag.gleam
+++ b/src/shelf/bag.gleam
@@ -19,9 +19,9 @@
 ///   bag.open(name: "tags", path: "data/tags.dets",
 ///     base_directory: "/app/data",
 ///     key: decode.string, value: decode.string)
-/// let assert Ok(Nil) = bag.insert(table, "color", "red")
-/// let assert Ok(Nil) = bag.insert(table, "color", "blue")
-/// let assert Ok(["red", "blue"]) = bag.lookup(table, "color")
+/// let assert Ok(Nil) = bag.insert(into: table, key: "color", value: "red")
+/// let assert Ok(Nil) = bag.insert(into: table, key: "color", value: "blue")
+/// let assert Ok(["red", "blue"]) = bag.lookup(from: table, key: "color")
 /// // values contains "red" and "blue" (order is unspecified)
 /// let assert Ok(Nil) = bag.save(table)
 /// let assert Ok(Nil) = bag.close(table)
@@ -128,7 +128,7 @@ pub fn close(table: PBag(k, v)) -> Result(Nil, ShelfError) {
 /// use table <- bag.with_table("tags", "tags.dets",
 ///   base_directory: "/app/data",
 ///   key: decode.string, value: decode.string)
-/// bag.insert(table, "color", "red")
+/// bag.insert(into: table, key: "color", value: "red")
 /// ```
 ///
 pub fn with_table(

--- a/src/shelf/duplicate_bag.gleam
+++ b/src/shelf/duplicate_bag.gleam
@@ -19,9 +19,9 @@
 ///   duplicate_bag.open(name: "events", path: "data/events.dets",
 ///     base_directory: "/app/data",
 ///     key: decode.string, value: decode.string)
-/// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "btn_1")
-/// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "btn_1")
-/// let assert Ok(["btn_1", "btn_1"]) = duplicate_bag.lookup(table, "click")
+/// let assert Ok(Nil) = duplicate_bag.insert(into: table, key: "click", value: "btn_1")
+/// let assert Ok(Nil) = duplicate_bag.insert(into: table, key: "click", value: "btn_1")
+/// let assert Ok(["btn_1", "btn_1"]) = duplicate_bag.lookup(from: table, key: "click")
 /// // values contains "btn_1" twice (order is unspecified)
 /// let assert Ok(Nil) = duplicate_bag.close(table)
 /// ```
@@ -128,7 +128,7 @@ pub fn close(table: PDuplicateBag(k, v)) -> Result(Nil, ShelfError) {
 /// use table <- duplicate_bag.with_table("events", "events.dets",
 ///   base_directory: "/app/data",
 ///   key: decode.string, value: decode.string)
-/// duplicate_bag.insert(table, "click", "btn_1")
+/// duplicate_bag.insert(into: table, key: "click", value: "btn_1")
 /// ```
 ///
 pub fn with_table(

--- a/src/shelf/set.gleam
+++ b/src/shelf/set.gleam
@@ -20,8 +20,8 @@
 ///   set.open(name: "users", path: "users.dets",
 ///     base_directory: "/app/data",
 ///     key: decode.string, value: decode.int)
-/// let assert Ok(Nil) = set.insert(table, "alice", 42)
-/// let assert Ok(42) = set.lookup(table, "alice")
+/// let assert Ok(Nil) = set.insert(into: table, key: "alice", value: 42)
+/// let assert Ok(42) = set.lookup(from: table, key: "alice")
 /// let assert Ok(Nil) = set.save(table)    // persist to disk
 /// let assert Ok(Nil) = set.close(table)   // auto-saves on close
 /// ```
@@ -137,7 +137,7 @@ pub fn close(table: PSet(k, v)) -> Result(Nil, ShelfError) {
 /// use table <- set.with_table("cache", "cache.dets",
 ///   base_directory: "/app/data",
 ///   key: decode.string, value: decode.string)
-/// set.insert(table, "key", "value")
+/// set.insert(into: table, key: "key", value: "value")
 /// ```
 ///
 pub fn with_table(
@@ -346,9 +346,9 @@ pub fn sync(table: PSet(k, v)) -> Result(Nil, ShelfError) {
 /// new value after incrementing. The increment can be negative.
 ///
 /// ```gleam
-/// let assert Ok(Nil) = set.insert(table, "hits", 0)
-/// let assert Ok(1) = set.update_counter(table, "hits", 1)
-/// let assert Ok(3) = set.update_counter(table, "hits", 2)
+/// let assert Ok(Nil) = set.insert(into: table, key: "hits", value: 0)
+/// let assert Ok(1) = set.update_counter(in: table, key: "hits", increment: 1)
+/// let assert Ok(3) = set.update_counter(in: table, key: "hits", increment: 2)
 /// ```
 ///
 /// In WriteThrough mode, the ETS atomic increment happens first (only ETS

--- a/website/src/content/docs/guides/write-modes.md
+++ b/website/src/content/docs/guides/write-modes.md
@@ -17,8 +17,8 @@ let assert Ok(table) =
   set.open(name: "sessions", path: "data/sessions.dets", base_directory: "/app/data", key: decode.string, value: decode.string)
 
 // Fast writes — ETS only
-let assert Ok(Nil) = set.insert(table, "user:1", session_1)
-let assert Ok(Nil) = set.insert(table, "user:2", session_2)
+let assert Ok(Nil) = set.insert(into: table, key: "user:1", value: session_1)
+let assert Ok(Nil) = set.insert(into: table, key: "user:2", value: session_2)
 
 // Persist to disk when ready
 let assert Ok(Nil) = set.save(table)
@@ -35,7 +35,7 @@ In WriteBack mode, data written since the last `save()` is lost if the process c
 Use `reload()` to discard unsaved ETS changes and restore from the last DETS snapshot:
 
 ```gleam
-let assert Ok(Nil) = set.insert(table, "temp", "data")
+let assert Ok(Nil) = set.insert(into: table, key: "temp", value: "data")
 // Changed our mind — discard unsaved changes
 let assert Ok(Nil) = set.reload(table)
 // "temp" key no longer exists
@@ -57,7 +57,7 @@ let config =
 let assert Ok(table) = set.open_config(config: config, key: decode.string, value: decode.string)
 
 // This writes to both ETS and DETS
-let assert Ok(Nil) = set.insert(table, "acct:1", account)
+let assert Ok(Nil) = set.insert(into: table, key: "acct:1", value: account)
 ```
 
 **Best for**: Data that must survive crashes with no loss — financial records, user accounts, configuration.
@@ -67,7 +67,7 @@ let assert Ok(Nil) = set.insert(table, "acct:1", account)
 DETS buffers writes internally for performance. After a WriteThrough write, the data is in DETS but may still be in the OS write buffer. Use `sync()` to force the DETS buffer to the filesystem:
 
 ```gleam
-let assert Ok(Nil) = set.insert(table, "critical", value)
+let assert Ok(Nil) = set.insert(into: table, key: "critical", value: value)
 let assert Ok(Nil) = set.sync(table)
 // Data is now on disk
 ```

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -27,11 +27,11 @@ pub fn main() {
     set.open(name: "users", path: "data/users.dets", base_directory: "/app/data", key: decode.string, value: decode.int)
 
   // Fast writes (to ETS)
-  let assert Ok(Nil) = set.insert(table, "alice", 42)
-  let assert Ok(Nil) = set.insert(table, "bob", 99)
+  let assert Ok(Nil) = set.insert(into: table, key: "alice", value: 42)
+  let assert Ok(Nil) = set.insert(into: table, key: "bob", value: 99)
 
   // Fast reads (from ETS)
-  let assert Ok(42) = set.lookup(table, "alice")
+  let assert Ok(42) = set.lookup(from: table, key: "alice")
 
   // Persist to disk when ready
   let assert Ok(Nil) = set.save(table)


### PR DESCRIPTION
Closes #54

Code examples across the README, website guides, inline `///` docstrings, and the `examples/` programs mixed positional and named-argument call styles for the same APIs (`insert`, `lookup`, `member`, `delete_*`, `update_counter`, etc.).

This PR converts every public-facing call site to named-argument form so each example is self-explanatory and call shapes stay consistent across surfaces. Function signatures and behavior are unchanged.

`gleam test` (138 tests) and `gleam check` on the examples package both pass.
