### PR TITLE
docs: reconcile save/sync durability story

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,14 @@ set.insert(into: table, key: "key", value: "value")
 | `sync(table)` | Flush DETS write buffer to OS |
 | `close(table)` | Save + close DETS + delete ETS |
 
-**`save` vs `sync`**: `save()` atomically copies ETS contents into DETS using a temp-file-plus-rename strategy for crash safety — use this in WriteBack mode to persist your changes. `sync()` flushes DETS's internal write buffer to the OS filesystem — use this in WriteThrough mode when you need to guarantee durability after a write (DETS buffers writes for performance).
+**`save` vs `sync`**: `save()` snapshots ETS → DETS using a temp-file +
+atomic rename (use in WriteBack to persist your changes). `sync()` drains
+DETS's internal write buffer into the open DETS file (use in WriteThrough
+when pending DETS writes need to be reflected in the on-disk file).
+
+For the precise per-call durability guarantees and crash semantics, see
+the canonical [Durability story](https://shelf.tylerbutler.com/advanced/persistence-operations/#durability-story)
+in the website docs.
 
 ## Type Safety
 

--- a/src/shelf/bag.gleam
+++ b/src/shelf/bag.gleam
@@ -257,7 +257,12 @@ pub fn delete_all(from table: PBag(k, v)) -> Result(Nil, ShelfError) {
 ///
 /// Uses an atomic save strategy: data is written to a temporary file
 /// first, then atomically renamed over the original DETS file. This
-/// prevents data loss if the process is killed mid-save.
+/// prevents data loss if the process is killed mid-save (the original
+/// file remains intact until the rename succeeds).
+///
+/// See the
+/// [Durability story](https://shelf.tylerbutler.com/advanced/persistence-operations/#durability-story)
+/// for the full layer-by-layer breakdown of which crashes this protects against.
 ///
 pub fn save(table: PBag(k, v)) -> Result(Nil, ShelfError) {
   internal.save(table.ets, table.dets)
@@ -274,11 +279,13 @@ pub fn reload(table: PBag(k, v)) -> Result(Nil, ShelfError) {
   internal.generic_reload(table.ets, table.dets, table.entry_decoder)
 }
 
-/// Flush the DETS write buffer to the OS.
+/// Drain the DETS in-memory write buffer into the open DETS file.
 ///
-/// DETS buffers writes internally. This forces them to be written
-/// to the underlying filesystem. Most useful in WriteThrough mode
-/// when you want to guarantee durability.
+/// Calls `dets:sync/1`. Most useful in WriteThrough mode after a critical
+/// write, to make sure pending DETS writes are reflected in the file on
+/// disk. Note: this does not call `fsync(2)` on the file descriptor — see
+/// the [Durability story](https://shelf.tylerbutler.com/advanced/persistence-operations/#durability-story)
+/// for what `sync()` does and does not guarantee.
 ///
 pub fn sync(table: PBag(k, v)) -> Result(Nil, ShelfError) {
   internal.sync_dets(table.ets, table.dets)

--- a/src/shelf/duplicate_bag.gleam
+++ b/src/shelf/duplicate_bag.gleam
@@ -268,7 +268,12 @@ pub fn delete_all(from table: PDuplicateBag(k, v)) -> Result(Nil, ShelfError) {
 ///
 /// Uses an atomic save strategy: data is written to a temporary file
 /// first, then atomically renamed over the original DETS file. This
-/// prevents data loss if the process is killed mid-save.
+/// prevents data loss if the process is killed mid-save (the original
+/// file remains intact until the rename succeeds).
+///
+/// See the
+/// [Durability story](https://shelf.tylerbutler.com/advanced/persistence-operations/#durability-story)
+/// for the full layer-by-layer breakdown of which crashes this protects against.
 ///
 pub fn save(table: PDuplicateBag(k, v)) -> Result(Nil, ShelfError) {
   internal.save(table.ets, table.dets)
@@ -285,11 +290,13 @@ pub fn reload(table: PDuplicateBag(k, v)) -> Result(Nil, ShelfError) {
   internal.generic_reload(table.ets, table.dets, table.entry_decoder)
 }
 
-/// Flush the DETS write buffer to the OS.
+/// Drain the DETS in-memory write buffer into the open DETS file.
 ///
-/// DETS buffers writes internally. This forces them to be written
-/// to the underlying filesystem. Most useful in WriteThrough mode
-/// when you want to guarantee durability.
+/// Calls `dets:sync/1`. Most useful in WriteThrough mode after a critical
+/// write, to make sure pending DETS writes are reflected in the file on
+/// disk. Note: this does not call `fsync(2)` on the file descriptor — see
+/// the [Durability story](https://shelf.tylerbutler.com/advanced/persistence-operations/#durability-story)
+/// for what `sync()` does and does not guarantee.
 ///
 pub fn sync(table: PDuplicateBag(k, v)) -> Result(Nil, ShelfError) {
   internal.sync_dets(table.ets, table.dets)

--- a/src/shelf/set.gleam
+++ b/src/shelf/set.gleam
@@ -308,6 +308,10 @@ pub fn delete_all(from table: PSet(k, v)) -> Result(Nil, ShelfError) {
 /// prevents data loss if the process is killed mid-save (the original
 /// file remains intact until the rename succeeds).
 ///
+/// See the
+/// [Durability story](https://shelf.tylerbutler.com/advanced/persistence-operations/#durability-story)
+/// for the full layer-by-layer breakdown of which crashes this protects against.
+///
 /// ```gleam
 /// // After a batch of writes...
 /// let assert Ok(Nil) = set.save(table)
@@ -328,11 +332,13 @@ pub fn reload(table: PSet(k, v)) -> Result(Nil, ShelfError) {
   internal.generic_reload(table.ets, table.dets, table.entry_decoder)
 }
 
-/// Flush the DETS write buffer to the OS.
+/// Drain the DETS in-memory write buffer into the open DETS file.
 ///
-/// DETS buffers writes internally. This forces them to be written
-/// to the underlying filesystem. Most useful in WriteThrough mode
-/// when you want to guarantee durability.
+/// Calls `dets:sync/1`. Most useful in WriteThrough mode after a critical
+/// write, to make sure pending DETS writes are reflected in the file on
+/// disk. Note: this does not call `fsync(2)` on the file descriptor — see
+/// the [Durability story](https://shelf.tylerbutler.com/advanced/persistence-operations/#durability-story)
+/// for what `sync()` does and does not guarantee.
 ///
 pub fn sync(table: PSet(k, v)) -> Result(Nil, ShelfError) {
   internal.sync_dets(table.ets, table.dets)

--- a/website/src/content/docs/advanced/persistence-operations.md
+++ b/website/src/content/docs/advanced/persistence-operations.md
@@ -35,6 +35,9 @@ let assert Ok(Nil) = set.save(table)
 
 In WriteThrough mode, every write goes to DETS directly (via `dets:insert`), so data is already persisted — you rarely need to call `save()` manually.
 
+For exactly which on-disk layer this call advances data past, and what
+guarantees it gives across crashes, see [Durability story](#durability-story).
+
 ## reload
 
 Clears the ETS table and loads all DETS contents into it. Discards any unsaved changes in ETS.
@@ -48,20 +51,54 @@ let assert Ok(Nil) = set.reload(table)
 
 ## sync
 
-Flushes the DETS internal write buffer to the OS filesystem. DETS buffers writes for performance — `sync()` forces those buffers to disk.
+Forces DETS's internal write buffer out to the open DETS file by calling
+`dets:sync/1`. Useful in WriteThrough mode after a critical write, when you
+need pending DETS buffers reflected in the on-disk file before continuing.
 
 ```gleam
 let assert Ok(Nil) = set.sync(table)
 ```
 
-**When to use**: In WriteThrough mode, after a critical write when you need to guarantee the data has reached the filesystem. In WriteBack mode, `sync()` is less useful since you control persistence via `save()`.
+In WriteBack mode `sync()` is rarely needed — `save()` already writes a
+fresh DETS file and reopens it.
 
-:::note[save vs sync]
-`save()` copies data from ETS into DETS. `sync()` flushes DETS's internal buffer to the OS. They serve different purposes:
-- After `save()`: data is in DETS but may be in OS buffers
-- After `sync()`: data is flushed from DETS buffers to the filesystem
-- For maximum durability: call `save()` then `sync()`
-:::
+## Durability story
+
+Data goes through several layers between an `insert()` call and physical
+storage. This section is the **single source of truth** for which call
+addresses which layer; other pages link here.
+
+| Layer | Where data lives | Call that advances data past this layer |
+|-------|------------------|------------------------------------------|
+| 1 | Application memory | `insert()`, `delete_*`, `update_counter` |
+| 2 | ETS table (in-process) | WriteBack: `save()`. WriteThrough: every write |
+| 3 | DETS in-memory buffer | `sync()` (open DETS) or `save()` (closes a temp DETS, which flushes) |
+| 4 | DETS file content (OS page cache) | `save()` writes a temp file then atomically `rename()`s over the original |
+| 5 | Physical disk | Not exposed — DETS does not surface `fsync(2)` on the file or its directory |
+
+What the calls actually do:
+
+- **`save()`** snapshots ETS → a *temporary* DETS file (`ets:to_dets/2`), closes
+  that temp file (flushing its buffer), then atomically `file:rename/2`s it
+  over the original DETS path and reopens at the original path. The rename
+  is POSIX-atomic, so a process or VM crash mid-`save()` leaves either the
+  previous file or the new file fully present — never a half-written file.
+- **`sync()`** calls `dets:sync/1` on the *currently open* DETS, draining its
+  in-memory write buffer into the file. It does **not** invoke `fsync(2)` on
+  the file descriptor and does **not** fsync the containing directory.
+- **`reload()`** discards the ETS table and rebuilds it from the on-disk DETS
+  file. It does not change durability — it changes which copy of the data
+  the table reflects.
+- **`close()`** performs a `save()` and then closes DETS / deletes ETS.
+
+Practical guarantees:
+
+| You want… | Then call |
+|-----------|-----------|
+| WriteBack changes safe across a process crash | `save()` |
+| WriteThrough writes flushed past DETS's buffer into the file | `sync()` |
+| Strongest crash safety shelf can provide | `save()` (atomic rename, then no further shelf call is needed in WriteBack) |
+| `fsync(2)`-level guarantees against OS crash / power loss | Not provided. If you need this, call out to a process that opens the DETS file path with `file:open/2` and `file:sync/1`, or place the data directory on a filesystem mounted with stronger durability semantics. |
 
 ## close
 

--- a/website/src/content/docs/guides/write-modes.md
+++ b/website/src/content/docs/guides/write-modes.md
@@ -64,20 +64,25 @@ let assert Ok(Nil) = set.insert(into: table, key: "acct:1", value: account)
 
 ### Guaranteeing Durability
 
-DETS buffers writes internally for performance. After a WriteThrough write, the data is in DETS but may still be in the OS write buffer. Use `sync()` to force the DETS buffer to the filesystem:
+After a WriteThrough write, the data has been handed to DETS but may still
+be in DETS's in-memory write buffer. Call `sync()` to drain that buffer
+into the on-disk DETS file:
 
 ```gleam
 let assert Ok(Nil) = set.insert(into: table, key: "critical", value: value)
 let assert Ok(Nil) = set.sync(table)
-// Data is now on disk
 ```
+
+`sync()` does **not** call `fsync(2)` on the underlying file. For the full
+layer-by-layer breakdown of what `save()` and `sync()` actually guarantee,
+see the canonical [Durability story](/advanced/persistence-operations/#durability-story).
 
 ## Comparison
 
 | | WriteBack | WriteThrough |
 |---|-----------|-------------|
 | Write speed | Fast (ETS only) | Slower (ETS + DETS) |
-| Data loss on crash | Since last `save()` | None (after `sync()`) |
+| Data loss on process crash | Since last `save()` | None — written DETS file survives |
 | When to persist | Manual `save()` call | Automatic on every write |
 | `reload()` useful? | Yes — discards unsaved changes | Not typically — ETS and DETS are in sync |
 | Best for | Caches, sessions, high-throughput | Accounts, config, audit logs |


### PR DESCRIPTION
Closes #55

The relationship between `save()`, `sync()`, and on-disk durability was described inconsistently across the website, README, and inline `///` docs: the README claimed `sync()` guarantees "data on disk" while the website noted OS buffers, and `write-modes.md` hinted that `save` + `sync` was the durable pattern.

This PR adds a single canonical **Durability story** section to `advanced/persistence-operations.md` that lays out every layer (app memory → ETS → DETS buffer → DETS file → OS page cache → physical disk) and which call advances data past which layer. The README and `write-modes.md` are reduced to short references; inline `///` docs on `save`/`sync` are tightened so all three modules agree word-for-word.

Notably, the docs no longer imply `sync()` reaches the physical disk — `dets:sync/1` does not call `fsync(2)`.
