### PR TITLE
docs: dedupe process-ownership and memory-cost notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,10 @@ let assert Ok(t) =
 
 Within a running session, Gleam's type system guarantees correctness — decoders only validate the DETS→ETS boundary at open time. The `save()` path is unaffected and still uses Erlang's efficient `ets:to_dets/2` bulk transfer.
 
-> **Performance note**: Loading from DETS (on `open` and `reload`) decodes and inserts entries one at a time via streaming (`dets:foldl`), keeping peak memory at ~1× table size. This is a one-time startup cost — all subsequent reads and writes remain at raw ETS speed.
+> **Performance note**: The DETS → ETS load streams entries through
+> `dets:foldl` and decodes them in batches, so peak extra memory during
+> open/reload is ~1× table size. See
+> [Memory cost on open and reload](https://shelf.tylerbutler.com/advanced/persistence-operations/#memory-cost-on-open-and-reload).
 
 ### Schema Migration
 
@@ -339,9 +342,9 @@ let assert Ok(entries) = set.to_list(from: t)
 - **Erlang only**: Requires the BEAM runtime (no JavaScript target)
 - **Single node**: DETS is local to one node (use Mnesia for distribution)
 - **Table names**: Names do not need to be globally unique — shelf uses unnamed ETS tables internally. However, DETS file paths must not conflict with other open tables.
-- **Process ownership**: ETS tables are owned by the process that created them. If that process exits, the ETS table is deleted and unsaved data is lost. The DETS file on disk is preserved and reloaded on the next `open()`. In long-running applications, ensure the process that opens tables is supervised.
+- **Process ownership**: ETS tables are owned by the process that called `open()` and are created `protected`, so reads work from any process but writes/lifecycle calls are owner-only. See [Process Ownership](https://shelf.tylerbutler.com/advanced/limitations/#process-ownership).
 - **DETS atoms**: DETS requires atom-based table names. Shelf uses a hash-based pool to bound the number of atoms created, so atom exhaustion is not a concern in normal usage.
-- **Opening large tables**: When opening a table, DETS entries are decoded and inserted one at a time via streaming (`dets:foldl`), reducing peak memory usage from ~3× table size to ~1×. This makes large table support practical, though startup time still scales linearly with table size.
+- **Opening large tables**: Open/reload streams DETS entries through `dets:foldl` for ~1× peak memory, but startup time still scales linearly with table size. Details and trade-offs: [Memory cost on open and reload](https://shelf.tylerbutler.com/advanced/persistence-operations/#memory-cost-on-open-and-reload).
 
 ## Security
 
@@ -349,20 +352,11 @@ All DETS file paths are validated against the provided `base_directory` to preve
 
 ## Process Ownership
 
-ETS tables are owned by the process that calls `open()`. This determines what each process can do:
+ETS tables are owned by the process that calls `open()`, and shelf creates them as `protected`. The website documents this in detail at [Process Ownership](https://shelf.tylerbutler.com/advanced/limitations/#process-ownership) — including the read/write split, `Error(NotOwner)` semantics, and recommended supervision patterns.
 
-- **Reads** (`lookup`, `member`, `to_list`, `fold`, `size`) work from **any** process — ETS tables are created as `protected`.
-- **Writes and lifecycle** (`insert`, `delete_*`, `update_counter`, `save`, `reload`, `sync`, `close`) are restricted to the **owner** process. Non-owner attempts return `Error(NotOwner)`.
-
-If you need cross-process writes, wrap the table in a supervised actor/server that owns the table and forwards mutation requests.
-
-### Crash Behavior
+In short: reads work from any process; writes and lifecycle calls (`insert`, `delete_*`, `update_counter`, `save`, `reload`, `sync`, `close`) must come from the owner.
 
 If the owning process crashes, the ETS table is deleted and unsaved data is lost. The DETS file is preserved — the next `open()` call reloads it.
-
-For long-running applications:
-- Open tables in a supervised process (e.g., an OTP GenServer or Gleam actor)
-- Consider periodic `save()` calls for WriteBack mode
 - Use WriteThrough mode for data that cannot tolerate loss
 
 ### Write Safety

--- a/website/src/content/docs/advanced/persistence-operations.md
+++ b/website/src/content/docs/advanced/persistence-operations.md
@@ -100,6 +100,23 @@ Practical guarantees:
 | Strongest crash safety shelf can provide | `save()` (atomic rename, then no further shelf call is needed in WriteBack) |
 | `fsync(2)`-level guarantees against OS crash / power loss | Not provided. If you need this, call out to a process that opens the DETS file path with `file:open/2` and `file:sync/1`, or place the data directory on a filesystem mounted with stronger durability semantics. |
 
+## Memory cost on open and reload
+
+When a table is opened (or reloaded), shelf streams DETS entries through
+`dets:foldl/3`, validates each entry through the user-supplied decoders,
+and inserts them into ETS in batches. Peak extra memory during this
+streaming load is roughly **~1× the table size** — the previous
+materialise-then-insert approach used ~3×.
+
+This is a one-time startup cost. After the load returns, all reads and
+writes happen at raw ETS speed (no further DETS I/O on the read path).
+Startup time still scales linearly with table size, so very large tables
+(hundreds of MB+) have noticeable open latency even though peak memory is
+bounded.
+
+This is the canonical reference for shelf's load-time memory and time
+cost; other pages link here.
+
 ## close
 
 Performs a final `save()`, closes the DETS file, and deletes the ETS table. The table handle must not be used after closing.


### PR DESCRIPTION
Closes #60

Two facts were duplicated across the README and website with subtly different wording:

- **Process ownership**: canonical home is now `advanced/limitations.md` (already mentions the `protected` ETS access mode). The README's full `## Process Ownership` section and Limitations bullet are collapsed into short cross-references that point there. The `## Process Ownership` heading is retained so the in-document anchor used by the error table still resolves.
- **Memory cost on open / reload**: canonical home is a new **Memory cost on open and reload** subsection in `advanced/persistence-operations.md`. The README's two duplicate mentions ("Performance note" and Limitations bullet) become short references.
