### PR TITLE
docs: add Schema Migration page and runnable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ Within a running session, Gleam's type system guarantees correctness — decoder
 If you change the key or value types between application versions, `open()` returns `Error(TypeMismatch(...))` because existing DETS data fails the new decoders.
 
 Strategies for handling schema changes:
-1. **Delete and rebuild**: Delete the DETS file and repopulate from your source of truth
-2. **Manual migration**: Write a one-time script that reads the old DETS file directly (via Erlang's `dets` module), transforms the data, and writes it back in the new format
+1. **Delete and rebuild**: Delete the DETS file and repopulate from your source of truth.
+2. **Run a migration**: Open the old DETS file with the *old* decoders as a temporary shelf table, transform the entries, write them to a temporary path with the *new* decoders, then atomically `rename` the new file over the old one and reopen.
+
+The website documents the procedure step-by-step at [Schema Migration](https://shelf.tylerbutler.com/advanced/schema-migration/), and a runnable end-to-end version lives at [`examples/src/schema_migration.gleam`](examples/src/schema_migration.gleam).
 
 ## Error Handling
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ cd examples && gleam run -m key_value_cache
 | [`event_log`](src/event_log.gleam) | `PDuplicateBag` | Duplicate preservation, fold, size, to_list, delete_object |
 | [`hit_counter`](src/hit_counter.gleam) | `PSet` | Atomic counters (update_counter), increment/decrement, fold aggregation |
 | [`safe_resource`](src/safe_resource.gleam) | `PSet` | with_table auto-close, save/reload checkpoints, sync |
+| [`schema_migration`](src/schema_migration.gleam) | `PSet` | Evolving the value type between app versions: temp shelf table + atomic file rename |
 
 ### key_value_cache
 
@@ -53,3 +54,7 @@ A page hit counter using `PSet` atomic counters. Demonstrates `update_counter` f
 Demonstrates two resource management patterns:
 1. **`with_table`** — automatic open/close via callback, guaranteed cleanup
 2. **Manual save/reload** — checkpoint data with `save()`, undo unsaved changes with `reload()`, and flush to disk with `sync()`
+
+### schema_migration
+
+A worked end-to-end migration that walks through the canonical 6-step procedure: open the old DETS file with the previous decoders, transform every entry to the new value shape (`String` → `#(String, Int)`), write the result to a temporary path, atomically `rename` it over the live file, then reopen with the new decoders. Mirrors the procedure documented at [Schema Migration](https://shelf.tylerbutler.com/advanced/schema-migration/).

--- a/examples/gleam.toml
+++ b/examples/gleam.toml
@@ -7,3 +7,4 @@ target = "erlang"
 gleam_stdlib = ">= 0.48.0 and < 2.0.0"
 gleam_erlang = ">= 1.0.0 and < 2.0.0"
 shelf = { path = ".." }
+simplifile = ">= 2.4.0 and < 3.0.0"

--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -2,12 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
-  { name = "gleam_stdlib", version = "0.70.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86949BF5D1F0E4AC0AB5B06F235D8A5CC11A2DFC33BF22F752156ED61CA7D0FF" },
-  { name = "shelf", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], source = "local", path = ".." },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "shelf", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], source = "local", path = ".." },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
 ]
 
 [requirements]
 gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
 shelf = { path = ".." }
+simplifile = { version = ">= 2.4.0 and < 3.0.0" }

--- a/examples/src/schema_migration.gleam
+++ b/examples/src/schema_migration.gleam
@@ -1,0 +1,158 @@
+/// Schema migration example: how to evolve key/value types between
+/// application versions without losing existing data.
+///
+/// **Scenario**: an older version of the app stored sessions as plain
+/// `String` user IDs. The new version wants to store them as
+/// `#(String, Int)` pairs (user ID + creation timestamp). Opening the
+/// new code against the old DETS file would fail with
+/// `Error(TypeMismatch(...))` because the new value decoder rejects
+/// the old data.
+///
+/// The procedure walks through the canonical 6-step migration:
+///
+///   1. Open the OLD DETS file as a temporary shelf table with the OLD
+///      decoders so existing entries pass validation.
+///   2. Read every entry with `to_list` (or `fold` for very large tables).
+///   3. Transform the value into the new shape.
+///   4. Write the transformed entries to a NEW path with the NEW decoders.
+///   5. Atomically replace the old DETS file with the new one
+///      (`simplifile.rename` is a POSIX rename on the same filesystem).
+///   6. Reopen the (now-migrated) file with the new decoders for normal use.
+///
+/// See https://shelf.tylerbutler.com/advanced/schema-migration/ for the
+/// prose version.
+import gleam/dynamic/decode
+import gleam/int
+import gleam/io
+import gleam/list
+import shelf/set
+import simplifile
+
+const data_dir = "/tmp"
+
+const live_path = "shelf_examples_migration.dets"
+
+const new_path = "shelf_examples_migration.new.dets"
+
+pub fn main() {
+  // Reset previous runs.
+  let _ = simplifile.delete(data_dir <> "/" <> live_path)
+  let _ = simplifile.delete(data_dir <> "/" <> new_path)
+
+  seed_v1_file()
+  io.println("✓ Seeded a v1 DETS file at " <> data_dir <> "/" <> live_path)
+
+  migrate()
+  io.println("✓ Migration complete")
+
+  reopen_and_print()
+
+  // Cleanup.
+  let _ = simplifile.delete(data_dir <> "/" <> live_path)
+  io.println("✓ Cleaned up example files")
+}
+
+// --- Setup: pretend a previous version of the app left a DETS file
+// --- behind whose values are plain strings. ----------------------------
+
+fn seed_v1_file() {
+  let assert Ok(legacy) =
+    set.open(
+      name: "sessions_v1",
+      path: live_path,
+      base_directory: data_dir,
+      key: decode.string,
+      value: decode.string,
+    )
+  let assert Ok(Nil) =
+    set.insert_list(into: legacy, entries: [
+      #("alice", "u-1001"),
+      #("bob", "u-1002"),
+      #("carol", "u-1003"),
+    ])
+  let assert Ok(Nil) = set.close(legacy)
+  Nil
+}
+
+// --- The 6-step migration. --------------------------------------------
+
+fn migrate() {
+  // Step 1: open OLD file with OLD decoders (so existing entries pass).
+  let assert Ok(old_table) =
+    set.open(
+      name: "sessions_v1_migration",
+      path: live_path,
+      base_directory: data_dir,
+      key: decode.string,
+      value: decode.string,
+    )
+
+  // Step 2: read every entry. Use `fold` instead of `to_list` for
+  //         very large tables to avoid materialising the whole list.
+  let assert Ok(old_entries) = set.to_list(from: old_table)
+
+  // Close the source before we touch the file on disk.
+  let assert Ok(Nil) = set.close(old_table)
+
+  // Step 3: transform values into the new shape `#(String, Int)`.
+  //         No real timestamps on disk — use 0 for legacy rows.
+  let new_entries =
+    list.map(old_entries, fn(entry) {
+      let #(name, user_id) = entry
+      #(name, #(user_id, 0))
+    })
+
+  // Step 4: write to a temporary NEW path with the NEW decoders.
+  let assert Ok(new_table) =
+    set.open(
+      name: "sessions_v2_migration",
+      path: new_path,
+      base_directory: data_dir,
+      key: decode.string,
+      value: new_value_decoder(),
+    )
+  let assert Ok(Nil) = set.insert_list(into: new_table, entries: new_entries)
+  let assert Ok(Nil) = set.close(new_table)
+
+  // Step 5: atomically replace the OLD file with the NEW file.
+  //         simplifile.rename is a POSIX rename when source and
+  //         destination are on the same filesystem — atomic from the
+  //         perspective of any future open() at `live_path`.
+  let assert Ok(Nil) =
+    simplifile.rename(data_dir <> "/" <> new_path, data_dir <> "/" <> live_path)
+  Nil
+}
+
+// Step 6: open the migrated file with the NEW decoders for normal use.
+fn reopen_and_print() {
+  let assert Ok(table) =
+    set.open(
+      name: "sessions_v2",
+      path: live_path,
+      base_directory: data_dir,
+      key: decode.string,
+      value: new_value_decoder(),
+    )
+  let assert Ok(entries) = set.to_list(from: table)
+  io.println("  migrated entries:")
+  list.each(entries, fn(entry) {
+    let #(name, value) = entry
+    let #(user_id, created_at) = value
+    io.println(
+      "    "
+      <> name
+      <> " -> user_id="
+      <> user_id
+      <> " created_at="
+      <> int.to_string(created_at),
+    )
+  })
+  let assert Ok(Nil) = set.close(table)
+  Nil
+}
+
+fn new_value_decoder() -> decode.Decoder(#(String, Int)) {
+  use user_id <- decode.field(0, decode.string)
+  use created_at <- decode.field(1, decode.int)
+  decode.success(#(user_id, created_at))
+}

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -102,6 +102,10 @@ export default defineConfig({
 							slug: "advanced/limitations",
 						},
 						{
+							label: "Schema Migration",
+							slug: "advanced/schema-migration",
+						},
+						{
 							label: "Troubleshooting",
 							slug: "advanced/troubleshooting",
 						},

--- a/website/src/content/docs/advanced/schema-migration.md
+++ b/website/src/content/docs/advanced/schema-migration.md
@@ -1,0 +1,155 @@
+---
+title: Schema Migration
+description: A 6-step procedure for evolving the key/value types in a shelf table without losing data.
+---
+
+When you change the key or value types your code uses for a shelf table
+between application versions, the next `open()` against the existing
+DETS file fails with `Error(TypeMismatch(...))` — the new decoders
+reject the on-disk entries.
+
+This page documents the canonical migration procedure. A runnable
+implementation lives at
+[`examples/src/schema_migration.gleam`](https://github.com/tylerbutler/shelf/blob/main/examples/src/schema_migration.gleam).
+
+## When to migrate vs. when to rebuild
+
+If the data is regenerable (a cache, a derived index), the simplest
+"migration" is to delete the DETS file and let your app rebuild it on
+next start. Only run a migration when the data is the source of truth or
+recomputing it would be expensive.
+
+## The procedure
+
+Most schema migrations follow the same six steps:
+
+### 1. Open the OLD file with the OLD decoders
+
+Open the existing DETS file as a temporary shelf table using the
+*previous* version's decoders, so existing entries pass validation.
+
+```gleam
+let assert Ok(old_table) =
+  set.open(
+    name: "sessions_v1_migration",
+    path: "sessions.dets",
+    base_directory: "/app/data",
+    key: decode.string,
+    value: decode.string, // old decoder
+  )
+```
+
+### 2. Read every entry
+
+Use `to_list` for tables that fit comfortably in memory, or `fold` for
+very large tables (folding streams entries one at a time without
+materialising the whole list).
+
+```gleam
+let assert Ok(old_entries) = set.to_list(from: old_table)
+let assert Ok(Nil) = set.close(old_table)
+```
+
+Close the source table before touching the file on disk in step 5.
+
+### 3. Transform values into the new shape
+
+Pure data transformation in Gleam — no shelf calls.
+
+```gleam
+let new_entries =
+  list.map(old_entries, fn(entry) {
+    let #(name, user_id) = entry
+    #(name, #(user_id, 0)) // legacy rows get timestamp 0
+  })
+```
+
+### 4. Write to a NEW path with the NEW decoders
+
+Open a fresh DETS file at a *different* path with the new decoders, then
+insert the transformed entries. Using a separate path means a crash
+during this step leaves the original file untouched.
+
+```gleam
+let assert Ok(new_table) =
+  set.open(
+    name: "sessions_v2_migration",
+    path: "sessions.new.dets",
+    base_directory: "/app/data",
+    key: decode.string,
+    value: new_value_decoder(),
+  )
+let assert Ok(Nil) = set.insert_list(into: new_table, entries: new_entries)
+let assert Ok(Nil) = set.close(new_table)
+```
+
+### 5. Atomically replace the OLD file with the NEW one
+
+Use a POSIX rename so the swap is atomic: any process that next opens
+the live path sees either the old file or the new file, never a
+half-written one.
+
+```gleam
+let assert Ok(Nil) =
+  simplifile.rename(
+    "/app/data/sessions.new.dets",
+    "/app/data/sessions.dets",
+  )
+```
+
+The rename must happen on the same filesystem to be atomic.
+
+### 6. Reopen normally with the NEW decoders
+
+The migration is complete. Open the live path the way the rest of your
+app expects:
+
+```gleam
+let assert Ok(table) =
+  set.open(
+    name: "sessions",
+    path: "sessions.dets",
+    base_directory: "/app/data",
+    key: decode.string,
+    value: new_value_decoder(),
+  )
+```
+
+## Frequently asked details
+
+### Does the new file need to live at the same path as the old one?
+
+No, but it usually should. The atom that shelf assigns to a path is
+derived from the path string, so reopening at the same path keeps the
+internal mapping stable across the migration. If you choose to keep the
+new file at a different path, update every `open()` call site that
+referenced the old path.
+
+### Should I delete the old file first?
+
+No — that would create a window where the data doesn't exist on disk.
+The point of the temp-file + rename pattern is that the live path
+*always* points at a complete, valid DETS file: either the old one or
+the new one.
+
+### How do I call `dets:open_file` directly from Gleam?
+
+You don't need to. shelf's `open()` already wraps `dets:open_file` and
+adds decoder-validated loading on top. For migrations, the recommended
+pattern is to use shelf with two different decoders (one per version)
+rather than dropping into raw Erlang.
+
+### Are there cleanup steps after the rename?
+
+If the migration succeeded, the old DETS file no longer exists (the
+rename overwrote it) and nothing further is required. If the migration
+fails partway, delete the temp `*.new.dets` file before retrying so the
+next attempt starts from a clean slate. shelf's internal atom registry
+and guardian process watch process exits, not file paths, so they do
+not need manual cleanup between migrations.
+
+### What about a "migration table" pattern?
+
+The procedure above effectively *is* the temporary-table pattern: the
+table opened in step 4 is a one-shot migration table that exists only
+for the duration of the rewrite. There is no separate API for it.

--- a/website/src/content/docs/advanced/troubleshooting.md
+++ b/website/src/content/docs/advanced/troubleshooting.md
@@ -38,9 +38,9 @@ You have three realistic options:
 2. **Delete the DETS file** — if the data is regenerable (a cache, an
    index), this is the simplest path.
 3. **Run a one-time migration** that opens the old DETS file with the
-   old decoders, transforms the entries, and writes them back. See the
-   [Schema Migration](https://github.com/tylerbutler/shelf#schema-migration)
-   section in the project README for the procedure.
+   old decoders, transforms the entries, and writes them back. See
+   [Schema Migration](/advanced/schema-migration/) for the full
+   procedure.
 
 The `decode_errors` value carried by `TypeMismatch` is the standard
 `gleam/dynamic/decode` error list — log it to see exactly which fields


### PR DESCRIPTION
Closes #58

The README's prior "Manual migration" bullet pointed at "write a script that uses Erlang's dets module" without an actual procedure. This PR replaces that with a concrete six-step procedure and a worked, runnable example.

- New `advanced/schema-migration.md` walks through the canonical procedure: open old file with old decoders → read entries → transform → write to a temp path with new decoders → atomic rename → reopen normally. Includes a FAQ block for the open questions in the issue (same path? delete first? raw `dets:open_file`? cleanup?).
- New `examples/src/schema_migration.gleam` runs the same procedure end-to-end, including seeding a v1 file and printing the migrated result. `simplifile` is added as an examples-only dep for the rename.
- Sidebar entry under Advanced; README now links to the new page; the troubleshooting page link to the procedure now points at the website instead of the README.
- `examples/README.md` gains a row and section for the new example.

I ran the example locally end-to-end:

```
$ gleam run -m schema_migration
✓ Seeded a v1 DETS file at /tmp/shelf_examples_migration.dets
✓ Migration complete
  migrated entries:
    alice -> user_id=u-1001 created_at=0
    bob -> user_id=u-1002 created_at=0
    carol -> user_id=u-1003 created_at=0
✓ Cleaned up example files
```
