### PR TITLE
ci: fix permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tylerbutler/shelf/security/code-scanning/1](https://github.com/tylerbutler/shelf/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access.  
Best fix without changing functionality: set:

- `contents: read`

at the workflow root (after `on:` and before `jobs:`). This is sufficient for `actions/checkout` and typical read-only CI tasks shown here (`just ci`, `just docs`), and does not grant write scopes.

No imports, methods, or dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
