### PR TITLE
feat(website): refresh typography and redesign splash page

### DIFF
--- a/.impeccable/critique/2026-07-20T06-29-33Z__website-src-content-docs-index-mdx.md
+++ b/.impeccable/critique/2026-07-20T06-29-33Z__website-src-content-docs-index-mdx.md
@@ -1,0 +1,66 @@
+---
+target: splash page (index.mdx)
+total_score: 29
+p0_count: 1
+p1_count: 1
+timestamp: 2026-07-20T06-29-33Z
+slug: website-src-content-docs-index-mdx
+---
+Method: dual-agent (A: critique-design-review · B: critique-detector)
+
+# Critique: shelf splash page (website/src/content/docs/index.mdx)
+
+## Design Health Score — 29/40 (Good)
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 2 | Limited surface; theme toggle, search, "Last updated" present |
+| 2 | Match System / Real World | 4 | Exact BEAM idiom (ETS/DETS/WriteBack); card-catalog logo |
+| 3 | User Control and Freedom | 3 | Theme toggle, search, low-commitment secondary CTA |
+| 4 | Consistency and Standards | 2 | Amber Starlight-default aside broke the berry system (since removed) |
+| 5 | Error Prevention | 3 | Code sample correct and labelled |
+| 6 | Recognition Rather Than Recall | 3 | Mobile code scrolls with no affordance cue |
+| 7 | Flexibility and Efficiency | 3 | Ctrl+K search, Auto theme, dual entry points |
+| 8 | Aesthetic and Minimalist Design | 3 | Docked for hero dead space + loud aside |
+| 9 | Error Recovery | 2 | Tinylytics analytics 404s silently |
+| 10 | Help and Documentation | 4 | Whole site is docs; clear CTAs, search, sidebar |
+| **Total** | | **29/40** | **Good** |
+
+## Anti-Patterns Verdict
+
+Not AI slop. No gradient text (the old rule was dead code, now deleted), no card grids, no eyebrows, no hero metrics, no numbered scaffolding, no overflow at 375px. The berry/ink monochrome is not guessable from "BEAM library docs."
+
+Deterministic scan: CLI scan of index.mdx clean (0 findings). In-page detector found 2: `side-tab` (border-left: 4px on the Starlight caution aside — the same element the design review flagged as P0; resolved by removing the stale Pre-1.0 notice) and `layout-transition` (transition: width,height on the framework body element — framework-origin, accepted).
+
+## Priority Issues
+
+- [P0 — RESOLVED] Stale amber Pre-1.0 warning: broke the berry system, front-loaded alarm at the adoption moment, and carried a banned 4px side-stripe. shelf shipped 1.0.1; component and all four usages deleted this session.
+- [P1] Desktop hero has ~130px dead space and a top-weighted text column against a centered illustration; mobile composes better. Fix: vertically center text against image or tighten hero height.
+- [P2] "Built in" is a 7-item flat group with an orphaned 7th cell (chunking failure, >4 per group). Fix: trim/merge to 6 or split into two labelled clusters.
+- [P2] Tinylytics embed 404s on every page — dead analytics plus console error. Fix: verify embed ID.
+- [P3] Mobile code block scrolls horizontally with no visible cue or copy button. Fix: edge fade or ensure copy button at mobile width.
+
+## Persona Red Flags
+
+- Jordan (first-timer): previously hit "not production-ready" before learning what shelf is — resolved by removal.
+- Casey (mobile): CTA thumb-reachable; code sample clips right with no cue; 404 wastes a request.
+- Riley (stress tester): overflow/contrast/zoom robust; orphan 7th cell and hero dead space look unfinished.
+- Priya (BEAM evaluator): gets the pattern immediately from real code — trust win. But the page never makes the "why shelf over bravo / raw DETS / SQLite" case she came for.
+
+## Strengths
+
+1. Palette commitment with real contrast discipline (feature text 9.93:1 dark theme); the No-Gray rule is executed, not just written.
+2. "Show the pattern, not the pitch" — real, correct Gleam right after the hero is the most persuasive element on the page.
+3. Restrained feature list (bare dl, no chrome) dodges the SaaS card-grid trap.
+
+## Minor Observations
+
+- Astro dev toolbar overlaps content in dev screenshots only; won't ship.
+- Dark-theme primary button matches DESIGN.md spec exactly (Accent Blush on Blackberry).
+- Mobile's centered hero composes better than desktop's left-aligned one.
+
+## Questions to Consider
+
+1. Now that the warning is gone, what earns its place as the first thing below the hero?
+2. Where's the comparison Priya came for? One honest trade-off line vs. raw DETS/bravo may do more for adoption than a 7th feature.
+3. Should desktop borrow mobile's centered hero — or put the code sample inside the hero so the first thing is working code?

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,111 @@
+{
+	"schemaVersion": 2,
+	"generatedAt": "2026-07-19T22:40:00-07:00",
+	"title": "Design System: shelf",
+	"extensions": {
+		"colorMeta": {
+			"boysenberry": {
+				"role": "primary",
+				"displayName": "Boysenberry",
+				"canonical": "#ab3772",
+				"tonalRamp": ["#340014", "#4d0022", "#6b0031", "#a2004e", "#ab3772", "#e24d80", "#f8aabe", "#ffe7ec"]
+			},
+			"mulberry-ink": {
+				"role": "primary",
+				"displayName": "Mulberry Ink",
+				"canonical": "#8f195a",
+				"tonalRamp": ["#340014", "#501e36", "#8f195a", "#a2004e", "#e24d80", "#f6a8bc", "#eeccd9", "#fff3f5"]
+			},
+			"blackberry-night": {
+				"role": "neutral",
+				"displayName": "Blackberry Night",
+				"canonical": "#340014",
+				"tonalRamp": ["#340014", "#4d0022", "#6b0031", "#a2004e", "#e24d80", "#f8aabe", "#ffe7ec", "#ffffff"]
+			},
+			"rose-paper": {
+				"role": "neutral",
+				"displayName": "Rose Paper",
+				"canonical": "#ffe7ec",
+				"tonalRamp": ["#340014", "#4d0022", "#6b0031", "#a2004e", "#e24d80", "#f8aabe", "#ffe7ec", "#fff3f5"]
+			}
+		},
+		"typographyMeta": {
+			"display": { "displayName": "Display", "purpose": "Page titles and hero wordmark line. Weight 650 is the signature." },
+			"heading": { "displayName": "Heading", "purpose": "Guide section headings (h2-h3), weight 650." },
+			"body": { "displayName": "Body", "purpose": "All prose at 1rem/1.65 — raised line-height gives the compact grotesque air." },
+			"code": { "displayName": "Code", "purpose": "All code, always Spline Sans Mono Variable. Never browser-default mono." }
+		},
+		"shadows": [],
+		"motion": [],
+		"breakpoints": []
+	},
+	"components": [
+		{
+			"name": "Primary Button",
+			"kind": "button",
+			"refersTo": "button-primary",
+			"description": "Accent-filled pill for the primary action (hero 'Get started').",
+			"html": "<button class=\"ds-btn-primary\">Get started</button>",
+			"css": ".ds-btn-primary { background: #8f195a; color: #ffffff; padding: 0.75rem 1.25rem; border: none; border-radius: 999rem; font-family: 'Spline Sans Variable', 'Spline Sans', sans-serif; font-weight: 600; font-size: 1rem; cursor: pointer; transition: background 0.2s; } .ds-btn-primary:hover { background: #a2004e; } .ds-btn-primary:focus-visible { outline: 2px solid #ab3772; outline-offset: 2px; }"
+		},
+		{
+			"name": "Secondary Button",
+			"kind": "button",
+			"refersTo": "button-secondary",
+			"description": "Text-only accent action ('What is shelf?').",
+			"html": "<button class=\"ds-btn-secondary\">What is shelf?</button>",
+			"css": ".ds-btn-secondary { background: transparent; color: #8f195a; padding: 0.75rem 1.25rem; border: none; border-radius: 999rem; font-family: 'Spline Sans Variable', 'Spline Sans', sans-serif; font-weight: 600; font-size: 1rem; cursor: pointer; } .ds-btn-secondary:hover { color: #a2004e; text-decoration: underline; } .ds-btn-secondary:focus-visible { outline: 2px solid #ab3772; outline-offset: 2px; }"
+		},
+		{
+			"name": "Caution Aside",
+			"kind": "card",
+			"description": "Starlight-style semantic callout; carries the site-wide Pre-1.0 notice.",
+			"html": "<div class=\"ds-aside\"><p class=\"ds-aside-title\">Pre-1.0 Software</p><p class=\"ds-aside-body\">The API is unstable and features may change in minor releases.</p></div>",
+			"css": ".ds-aside { background: #fff3f5; border: 1px solid #f6a8bc; border-radius: 0.5rem; padding: 1rem 1.25rem; font-family: 'Spline Sans Variable', 'Spline Sans', sans-serif; } .ds-aside-title { color: #6b0031; font-weight: 650; margin: 0 0 0.375rem; font-size: 1rem; } .ds-aside-body { color: #4d0022; margin: 0; font-size: 0.9375rem; line-height: 1.65; }"
+		},
+		{
+			"name": "Code Block",
+			"kind": "custom",
+			"description": "The most-read component on the site — tinted berry surface, hairline border, Spline Sans Mono.",
+			"html": "<pre class=\"ds-code\"><code>import shelf/set\n\nlet assert Ok(table) = set.open(config)</code></pre>",
+			"css": ".ds-code { background: #fff3f5; border: 1px solid #ffe7ec; border-radius: 0.5rem; padding: 1rem 1.25rem; margin: 0; overflow-x: auto; } .ds-code code { font-family: 'Spline Sans Mono Variable', 'Spline Sans Mono', ui-monospace, monospace; font-size: 0.8125rem; line-height: 1.65; color: #4d0022; }"
+		},
+		{
+			"name": "Sidebar Nav Link",
+			"kind": "nav",
+			"description": "Current page marked with accent tint + accent text; others quiet.",
+			"html": "<nav class=\"ds-nav\"><a class=\"ds-nav-link\" href=\"#\">Installation</a><a class=\"ds-nav-link ds-nav-current\" href=\"#\">Quick Start</a><a class=\"ds-nav-link\" href=\"#\">Set Tables</a></nav>",
+			"css": ".ds-nav { display: flex; flex-direction: column; gap: 2px; font-family: 'Spline Sans Variable', 'Spline Sans', sans-serif; } .ds-nav-link { color: #4d0022; text-decoration: none; padding: 0.375rem 0.75rem; border-radius: 0.5rem; font-size: 0.9375rem; } .ds-nav-link:hover { background: #ffe7ec; } .ds-nav-current { background: #eeccd9; color: #8f195a; font-weight: 600; } .ds-nav-link:focus-visible { outline: 2px solid #ab3772; outline-offset: -2px; }"
+		}
+	],
+	"narrative": {
+		"northStar": "The Card Catalog",
+		"overview": "shelf's documentation site is a great library's index: warm wood-and-ink materiality on the surface, instant and exact retrieval underneath. That is the product itself — ETS-speed lookups with disk permanence — expressed visually. The berry-and-ink palette carries the warmth; the type system and Starlight's information architecture carry the precision. Nothing on the page is decorative that doesn't help a reader find, read, or trust.",
+		"keyCharacteristics": [
+			"Monochromatic berry palette — no true grays anywhere; every neutral carries the brand hue",
+			"One type superfamily (Spline Sans + Spline Sans Mono) across UI, prose, and code",
+			"Flat, tonally-layered surfaces; depth from the berry ramp, not shadows",
+			"Restrained components that disappear into the reading"
+		],
+		"rules": [
+			{ "name": "The No-Gray Rule", "body": "There are no neutral grays in this system. Every 'gray' is a berry-tinted value from the ramp. Introducing a true gray (or a blue-tinted slate) is a violation; it instantly reads as unthemed.", "section": "colors" },
+			{ "name": "The Two-Ends Rule", "body": "Dark and light themes are the same ramp read from opposite ends, not two palettes. A new color must be placed on the ramp and verified at ≥4.5:1 for body text in both themes before use.", "section": "colors" },
+			{ "name": "The One Family Rule", "body": "Spline Sans and Spline Sans Mono are the only typefaces. Hierarchy comes from the variable weight axis (400 body / 650 headings), never from a new face.", "section": "typography" },
+			{ "name": "The Designed Code Rule", "body": "Code is first-class content on this site. It never renders in a browser-default mono stack; --sl-font-mono must resolve to Spline Sans Mono Variable.", "section": "typography" },
+			{ "name": "The Tonal-Depth Rule", "body": "To elevate a surface, move one step along the berry ramp. Never add a box-shadow to create hierarchy on cards, asides, or navigation.", "section": "elevation" }
+		],
+		"dos": [
+			"Do place every new color on the berry ramp and verify ≥4.5:1 body contrast in both themes (The Two-Ends Rule).",
+			"Do use variable weight (400 → 650) as the only hierarchy axis in type; 650 is the heading weight, exactly.",
+			"Do keep code in Spline Sans Mono everywhere — code is first-class content (The Designed Code Rule).",
+			"Do elevate surfaces tonally, one ramp step at a time (The Tonal-Depth Rule)."
+		],
+		"donts": [
+			"Don't build 'generic SaaS landing' grammar — gradient heroes, hero metrics, identical icon-heading-text card grids.",
+			"Don't let any surface regress to 'sterile default Starlight' — the unthemed template look is a named anti-reference.",
+			"Don't ship anything that reads as a 'toy project': placeholder copy, broken polish, sparse half-pages.",
+			"Don't use gradient text (background-clip: text). The splash hero currently does this; it is scheduled for removal, not imitation.",
+			"Don't introduce true grays, blue-tinted slates, a third typeface, or box-shadow hierarchy."
+		]
+	}
+}

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -59,8 +59,8 @@
 		{
 			"name": "Caution Aside",
 			"kind": "card",
-			"description": "Starlight-style semantic callout; carries the site-wide Pre-1.0 notice.",
-			"html": "<div class=\"ds-aside\"><p class=\"ds-aside-title\">Pre-1.0 Software</p><p class=\"ds-aside-body\">The API is unstable and features may change in minor releases.</p></div>",
+			"description": "Starlight-style semantic callout for notes, cautions, and tips.",
+			"html": "<div class=\"ds-aside\"><p class=\"ds-aside-title\">Heads up</p><p class=\"ds-aside-body\">DETS files have a 2 GB size limit; plan table growth accordingly.</p></div>",
 			"css": ".ds-aside { background: #fff3f5; border: 1px solid #f6a8bc; border-radius: 0.5rem; padding: 1rem 1.25rem; font-family: 'Spline Sans Variable', 'Spline Sans', sans-serif; } .ds-aside-title { color: #6b0031; font-weight: 650; margin: 0 0 0.375rem; font-size: 1rem; } .ds-aside-body { color: #4d0022; margin: 0; font-size: 0.9375rem; line-height: 1.65; }"
 		},
 		{

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+	"files": ["website/src/components/Head.astro"],
+	"insertBefore": "</Default>",
+	"commentSyntax": "html",
+	"cspChecked": true
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,12 @@ The `shelf_ffi.erl` module wraps raw `ets:*` and `dets:*` calls with error trans
 - Follow `gleam format` output
 - Document public functions with `///` comments
 - Test files create temporary `.dets` files in `/tmp/` and clean up after each test
+
+## Design Context
+
+The `website/` docs site (Astro/Starlight, deployed to shelf.tylerbutler.com) has captured design context:
+
+- **PRODUCT.md** (repo root) — strategy: product register, web platform, users, positioning, brand personality, anti-references
+- **DESIGN.md** (repo root) — visual system: berry/ink palette, Spline Sans + Spline Sans Mono typography, named rules
+
+Read both before any design or website work; keep changes consistent with their rules.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,151 @@
+---
+name: shelf
+description: Persistent ETS tables backed by DETS for Gleam.
+colors:
+  boysenberry: "#ab3772"
+  mulberry-ink: "#8f195a"
+  blackberry-night: "#340014"
+  deep-currant: "#6b0031"
+  berry-stain: "#a2004e"
+  raspberry-glow: "#ff729e"
+  petal-pink: "#f8aabe"
+  accent-blush: "#e6bbcb"
+  rose-paper: "#ffe7ec"
+  blush-white: "#fff3f5"
+  pure-white: "#ffffff"
+typography:
+  display:
+    fontFamily: "Spline Sans Variable, Spline Sans, sans-serif"
+    fontSize: "2.5rem"
+    fontWeight: 650
+    lineHeight: 1.2
+  heading:
+    fontFamily: "Spline Sans Variable, Spline Sans, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 650
+    lineHeight: 1.25
+  body:
+    fontFamily: "Spline Sans Variable, Spline Sans, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.65
+  code:
+    fontFamily: "Spline Sans Mono Variable, Spline Sans Mono, ui-monospace, monospace"
+    fontSize: "0.8125rem"
+    fontWeight: 400
+    lineHeight: 1.65
+components:
+  button-primary:
+    backgroundColor: "{colors.mulberry-ink}"
+    textColor: "{colors.pure-white}"
+    rounded: "999rem"
+    padding: "0.75rem 1.25rem"
+  button-secondary:
+    textColor: "{colors.mulberry-ink}"
+    rounded: "999rem"
+    padding: "0.75rem 1.25rem"
+---
+
+# Design System: shelf
+
+## 1. Overview
+
+**Creative North Star: "The Card Catalog"**
+
+shelf's documentation site is a great library's index: warm wood-and-ink materiality on the surface, instant and exact retrieval underneath. That is the product itself — ETS-speed lookups with disk permanence — expressed visually. The berry-and-ink palette carries the warmth; the type system and Starlight's information architecture carry the precision. Nothing on the page is decorative that doesn't help a reader find, read, or trust.
+
+The system explicitly rejects the generic SaaS landing (gradient heroes, hero metrics, interchangeable feature grids), the sterile unthemed Starlight default, and anything that reads as a toy project. It is a themed, maintained, personality-carrying documentation site for working BEAM developers.
+
+**Key Characteristics:**
+- Monochromatic berry palette — there are no true grays anywhere; every neutral carries the brand hue
+- One type superfamily (Spline Sans + Spline Sans Mono) across UI, prose, and code
+- Flat, tonally-layered surfaces; depth from the berry ramp, not shadows
+- Restrained components that disappear into the reading
+
+## 2. Colors: The Berry & Ink Palette
+
+A single hue family, stretched from near-black blackberry to blush white — commitment to one color, differentiated entirely by lightness.
+
+### Primary
+- **Boysenberry** (#ab3772): The accent in dark theme — links, current sidebar item, interactive highlights against Blackberry Night.
+- **Mulberry Ink** (#8f195a): The accent in light theme — the same voice, darkened to hold 4.5:1 against white paper. Primary buttons and links in light mode.
+
+### Neutral
+The "grays" are a berry-tinted lightness ramp; the two themes read it from opposite ends.
+- **Blackberry Night** (#340014): The deepest value — page ground in dark theme, primary ink in light theme.
+- **Deep Currant** (#6b0031) and **Berry Stain** (#a2004e): Mid-ramp values for borders, secondary text, and surface layering.
+- **Raspberry Glow** (#ff729e) and **Petal Pink** (#f8aabe): Upper mid-ramp — secondary text in dark theme, decorative tints in light.
+- **Accent Blush** (#e6bbcb): High-contrast accent text/fills on dark surfaces.
+- **Rose Paper** (#ffe7ec) and **Blush White** (#fff3f5): The palest tints — light-theme surfaces and dark-theme primary text.
+- **Pure White** (#ffffff): Light-theme page ground and maximal text on dark.
+
+### Named Rules
+**The No-Gray Rule.** There are no neutral grays in this system. Every "gray" is a berry-tinted value from the ramp above. Introducing a true gray (or a blue-tinted slate) is a violation; it instantly reads as unthemed.
+
+**The Two-Ends Rule.** Dark and light themes are the same ramp read from opposite ends, not two palettes. A new color must be placed on the ramp and verified at ≥4.5:1 for body text in both themes before use.
+
+## 3. Typography
+
+**Display Font:** Spline Sans Variable (with sans-serif fallback)
+**Body Font:** Spline Sans Variable (same family)
+**Code Font:** Spline Sans Mono Variable (with ui-monospace fallback)
+
+**Character:** A true superfamily — the warm, slightly compact grotesque and its matching mono share one skeleton, so headings, prose, and code read as one voice. Precise letterforms with friendly curves: "precise, warm, confident" without geometric coldness.
+
+### Hierarchy
+- **Display** (650, ~2.5rem, 1.2): Page titles and the hero wordmark line. Weight 650 — deliberately between semibold and bold — is the signature of confident headings here.
+- **Heading** (650, Starlight scale h2–h3, 1.25): Section headings in guides.
+- **Body** (400, 1rem, 1.65): All prose. Line-height is raised to 1.65 to give the compact grotesque air in long-form reading.
+- **Code** (400, 0.8125rem, 1.65): All code blocks and inline code, always Spline Sans Mono.
+
+### Named Rules
+**The One Family Rule.** Spline Sans and Spline Sans Mono are the only typefaces. No third family, no display font for flavor. Hierarchy comes from the variable weight axis (400 body / 650 headings), never from a new face.
+
+**The Designed Code Rule.** Code is first-class content on this site. It never renders in a browser-default mono stack; `--sl-font-mono` must resolve to Spline Sans Mono Variable.
+
+## 4. Elevation
+
+Flat with tonal layering. Depth is conveyed by stepping along the berry ramp — a panel sits "above" the page by being one ramp step lighter (dark theme) or by a hairline border on Rose Paper (light theme). Shadows appear only where Starlight itself uses them (the search modal); nothing else casts one.
+
+### Named Rules
+**The Tonal-Depth Rule.** To elevate a surface, move one step along the berry ramp. Never add a box-shadow to create hierarchy on cards, asides, or navigation.
+
+## 5. Components
+
+The component vocabulary is Starlight's, themed — refined and restrained: quiet controls that disappear into the reading, with the berry accent marking actions and current location only.
+
+### Buttons
+- **Shape:** Pill (999rem radius, Starlight default).
+- **Primary:** Accent-filled — Mulberry Ink on white text in light theme; Accent Blush fill with Blackberry Night text in dark theme.
+- **Secondary:** Text-only with accent color; no fill, no border.
+- **Hover / Focus:** Starlight defaults; focus rings use the accent.
+
+### Cards / Containers
+- **Corner Style:** Gently rounded (0.5rem, Starlight default).
+- **Background:** One ramp step off the page ground (see Elevation).
+- **Border:** Hairline in the mid-ramp (Deep Currant on dark, Rose Paper on light).
+- **Shadow Strategy:** None (The Tonal-Depth Rule).
+
+### Asides / Callouts
+- Starlight `<Aside>` components carry all notices (the Pre-1.0 caution is site-wide via `PreReleaseNotice.astro`). Use semantic types (`note`, `caution`, `tip`); never hand-build a callout.
+
+### Code Blocks
+- Spline Sans Mono at 0.8125rem on a tinted berry surface with hairline border. Code blocks are the site's most-read component; they must look deliberate in both themes.
+
+### Navigation
+- Starlight sidebar; current page marked with accent background tint + accent text. Wordmark image replaces the site title (light/dark variants in `src/assets/`).
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** place every new color on the berry ramp and verify ≥4.5:1 body contrast in both themes (The Two-Ends Rule).
+- **Do** use variable weight (400 → 650) as the only hierarchy axis in type; 650 is the heading weight, exactly.
+- **Do** keep code in Spline Sans Mono everywhere — code is first-class content (The Designed Code Rule).
+- **Do** elevate surfaces tonally, one ramp step at a time (The Tonal-Depth Rule).
+
+### Don't:
+- **Don't** build "generic SaaS landing" grammar — gradient heroes, hero metrics, identical icon-heading-text card grids (PRODUCT.md anti-reference, verbatim).
+- **Don't** let any surface regress to "sterile default Starlight" — the unthemed template look is a named anti-reference.
+- **Don't** ship anything that reads as a "toy project": placeholder copy, broken polish, sparse half-pages.
+- **Don't** use gradient text (`background-clip: text`). The splash hero currently does this; it is scheduled for removal, not imitation.
+- **Don't** introduce true grays, blue-tinted slates, a third typeface, or box-shadow hierarchy.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -127,7 +127,7 @@ The component vocabulary is Starlight's, themed — refined and restrained: quie
 - **Shadow Strategy:** None (The Tonal-Depth Rule).
 
 ### Asides / Callouts
-- Starlight `<Aside>` components carry all notices (the Pre-1.0 caution is site-wide via `PreReleaseNotice.astro`). Use semantic types (`note`, `caution`, `tip`); never hand-build a callout.
+- Starlight `<Aside>` components carry all notices. Use semantic types (`note`, `caution`, `tip`); never hand-build a callout.
 
 ### Code Blocks
 - Spline Sans Mono at 0.8125rem on a tinted berry surface with hairline border. Code blocks are the site's most-read component; they must look deliberate in both themes.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,42 @@
+# Product
+
+## Register
+
+product
+
+## Platform
+
+web
+
+## Users
+
+Gleam and BEAM developers evaluating persistence options for their applications — comparing shelf against raw DETS, bravo, SQLite, or running a database process. They are technically fluent, know (or half-remember) the classic Erlang ETS/DETS pattern, and want to know quickly whether shelf fits. Secondary audience: developers already using shelf who return to the guides for write-mode decisions, persistence operations, and troubleshooting.
+
+## Product Purpose
+
+The site documents shelf, a Gleam library providing persistent ETS tables backed by DETS — fast in-memory access with automatic disk persistence on the BEAM. The site exists so evaluators can understand and trust the library fast, and so users can self-serve on guides and advanced topics. Success is adoption: installs from Hex, completed quick-starts, developers choosing shelf.
+
+## Positioning
+
+The classic Erlang ETS+DETS persistence pattern, wrapped in a type-safe Gleam API. Every page reinforces that shelf is the familiar BEAM idiom made safe — not a new database, not a toy.
+
+## Brand Personality
+
+Precise, warm, confident. Technically exact documentation carried by the warmth of the berry/magenta palette — approachable expertise. The voice is direct and concrete: real code, honest trade-offs, no hype.
+
+## Anti-references
+
+- Generic SaaS landing grammar: gradient heroes, hero metrics, identical feature-card grids — startup marketing on a library site.
+- Sterile default Starlight: an obviously-unthemed docs template that could be any project, losing shelf's identity.
+- Anything that reads as a toy project: sparse pages, broken polish, placeholder copy, signs of abandonment.
+
+## Design Principles
+
+- **Show the pattern, not the pitch.** Evaluators know the BEAM. Lead with real code and the familiar ETS/DETS idiom; let working examples persuade.
+- **Fast path to first table.** Success is adoption, so every entry point should shorten the distance to a completed quick-start.
+- **Honest about trade-offs.** Confidence includes limitations. Direct answers about write modes, durability, and what shelf doesn't do build more trust than overselling.
+- **Identity without noise.** The berry palette, Metropolis type, and wordmark carry the warmth; layout and hierarchy stay precise and reading-first.
+
+## Accessibility & Inclusion
+
+WCAG AA: body text at ≥4.5:1 contrast in both light and dark themes, full keyboard navigability, and reduced-motion alternatives for any animation. Verify the magenta-heavy gray ramps hold AA on both themes.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -34,8 +34,8 @@ export default defineConfig({
 			},
 			favicon: "./src/assets/favicon.png",
 			customCss: [
-				"@fontsource/metropolis/400.css",
-				"@fontsource/metropolis/600.css",
+				"@fontsource-variable/spline-sans",
+				"@fontsource-variable/spline-sans-mono",
 				"./src/styles/fonts.css",
 				"./src/styles/custom.css",
 			],

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,8 @@
 	"dependencies": {
 		"@astrojs/check": "^0.9.6",
 		"@astrojs/starlight": "^0.37.0",
-		"@fontsource/metropolis": "^5.2.5",
+		"@fontsource-variable/spline-sans": "^5.3.0",
+		"@fontsource-variable/spline-sans-mono": "^5.3.0",
 		"astro": "^5.18.1",
 		"astro-mermaid": "^1.3.1",
 		"astro-tinylytics": "^0.1.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -14,9 +14,12 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.37.0
         version: 0.37.7(astro@5.18.1(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.2))
-      '@fontsource/metropolis':
-        specifier: ^5.2.5
-        version: 5.2.5
+      '@fontsource-variable/spline-sans':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource-variable/spline-sans-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       astro:
         specifier: ^5.18.1
         version: 5.18.1(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.2)
@@ -511,8 +514,11 @@ packages:
     resolution: {integrity: sha512-Au3jSkt66PRwTKTCYm7KzTGfMzUmn1LYPK+cyrytfzjfOPkHpohrLcGYPLsgxV8nzc4vXxt3Ay7MlBrmeIfFLg==}
     engines: {node: '>=16.0'}
 
-  '@fontsource/metropolis@5.2.5':
-    resolution: {integrity: sha512-zAz6XS1ZXVXZadcqsOnToiePAKEiEywxOwILEaE4sRl+pVOFQI/30xMiKvjQae1NRK3TbeKxJAmt+yFkPguXJw==}
+  '@fontsource-variable/spline-sans-mono@5.3.0':
+    resolution: {integrity: sha512-dH/qBj/MCE4ObiuCwlA9X1o3AftMO9dwfFgoRVYjy6VCPYkpWAlEtK/RjeyICgsR8rW763IAQARskVgShBY5JA==}
+
+  '@fontsource-variable/spline-sans@5.3.0':
+    resolution: {integrity: sha512-a0EVY1u6qvI5uk66ImOKbh3QD8y3LtMpuqMMyN4OB9eJwivKPXNTn8rJUB+YLrJ5LxS85vqSmG1xeYG/mF8MDw==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -1035,6 +1041,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -2511,6 +2518,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -3324,7 +3332,9 @@ snapshots:
       mdast-util-find-and-replace: 1.1.1
       unist-util-visit: 2.0.3
 
-  '@fontsource/metropolis@5.2.5': {}
+  '@fontsource-variable/spline-sans-mono@5.3.0': {}
+
+  '@fontsource-variable/spline-sans@5.3.0': {}
 
   '@iconify/types@2.0.0': {}
 

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
 onlyBuiltDependencies:
   - esbuild
   - sharp

--- a/website/src/components/PreReleaseNotice.astro
+++ b/website/src/components/PreReleaseNotice.astro
@@ -1,9 +1,0 @@
----
-import { Aside } from "@astrojs/starlight/components";
----
-
-<Aside type="caution" title="Pre-1.0 Software">
-	shelf is not yet 1.0. The API is unstable, features may be removed
-	in minor releases, and quality should not be considered production-ready.
-	We welcome usage and feedback in the meantime!
-</Aside>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -17,10 +17,6 @@ hero:
       variant: secondary
 ---
 
-import PreReleaseNotice from '../../components/PreReleaseNotice.astro';
-
-<PreReleaseNotice />
-
 ## The pattern
 
 Reads come from ETS at memory speed; writes persist to DETS on disk. shelf wraps

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -17,44 +17,74 @@ hero:
       variant: secondary
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
 import PreReleaseNotice from '../../components/PreReleaseNotice.astro';
 
 <PreReleaseNotice />
 
-## Features
+## The pattern
 
-<style lang="css">{`
-  // Add a gradient to the heading on the splash page.
-  #_top {
-    background: linear-gradient(90deg, var(--sl-color-gray-2), var(--sl-color-accent));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-  }
-`}
-</style>
+Reads come from ETS at memory speed; writes persist to DETS on disk. shelf wraps
+the classic Erlang persistence pattern in a type-safe Gleam API, with decoders
+validating every entry loaded from disk before it reaches your code.
 
-<CardGrid>
-	<Card title="ETS Speed + DETS Persistence" icon="rocket">
-		Microsecond reads from ETS with durable storage on disk via DETS. The classic Erlang persistence pattern, wrapped in a type-safe Gleam API.
-	</Card>
-	<Card title="Runtime Type Safety" icon="approve-check-circle">
-		Decoder-gated loading validates every entry from disk against your Gleam types. Catch corrupted or mistyped data at the storage boundary.
-	</Card>
-	<Card title="Write Modes" icon="document">
-		Choose WriteBack for high-throughput batched persistence, or WriteThrough for immediate durability on every write.
-	</Card>
-	<Card title="Table Types" icon="list-format">
-		Set, bag, and duplicate bag tables — all with persistent backing. Pick the right data model for your use case.
-	</Card>
-	<Card title="Safe Resource Management" icon="setting">
-		The `with_table` callback ensures tables are always properly closed, even when the body panics or returns an error.
-	</Card>
-	<Card title="Atomic Counters" icon="puzzle">
-		Lock-free integer increments via `update_counter` — increment hit counts or sequence numbers without serialising through an actor.
-	</Card>
-	<Card title="Cross-process reads" icon="seti:plan">
-		ETS tables are created `protected`, so any process can read them concurrently while a single owner process handles writes — a natural fit for actor-fronted, read-heavy services.
-	</Card>
-</CardGrid>
+```gleam
+import gleam/dynamic/decode
+import shelf/set
+
+// Open a persistent set — existing data loads from disk, through your decoders
+let assert Ok(table) =
+  set.open(
+    name: "users",
+    path: "data/users.dets",
+    base_directory: "/app/data",
+    key: decode.string,
+    value: decode.int,
+  )
+
+// Writes and reads hit ETS at memory speed
+let assert Ok(Nil) = set.insert(into: table, key: "alice", value: 42)
+let assert Ok(42) = set.lookup(from: table, key: "alice")
+
+// Persist to disk when ready; close auto-saves
+let assert Ok(Nil) = set.save(table)
+```
+
+## Built in
+
+<dl class="splash-features">
+  <div>
+    <dt>ETS speed, DETS persistence</dt>
+    <dd>Microsecond reads from memory, durable storage on disk — no database
+    process to run.</dd>
+  </div>
+  <div>
+    <dt>Runtime type safety</dt>
+    <dd>Decoder-gated loading catches corrupted or mistyped data at the storage
+    boundary, not in production.</dd>
+  </div>
+  <div>
+    <dt>Two write modes</dt>
+    <dd>WriteBack for high-throughput batching, or WriteThrough for immediate
+    durability on every write.</dd>
+  </div>
+  <div>
+    <dt>Set, bag, and duplicate bag</dt>
+    <dd>All three ETS table types, each with persistent backing — pick the data
+    model your use case needs.</dd>
+  </div>
+  <div>
+    <dt>Safe resource management</dt>
+    <dd>The <code>with_table</code> callback closes tables even when the body
+    panics or returns an error.</dd>
+  </div>
+  <div>
+    <dt>Atomic counters</dt>
+    <dd>Lock-free increments via <code>update_counter</code> — no serialising
+    through an actor.</dd>
+  </div>
+  <div>
+    <dt>Cross-process reads</dt>
+    <dd>Tables are <code>protected</code>: one owner process writes while any
+    process reads concurrently.</dd>
+  </div>
+</dl>

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -45,6 +45,20 @@ let assert Ok(42) = set.lookup(from: table, key: "alice")
 let assert Ok(Nil) = set.save(table)
 ```
 
+## Compared to the alternatives
+
+Gleam's ETS ecosystem already covers the pieces individually — shelf exists
+because most projects need both at once.
+
+- **[bravo](https://hexdocs.pm/bravo)** wraps ETS. Fast, in-memory only;
+  nothing survives a restart.
+- **[slate](https://slate.hexdocs.pm)** wraps DETS. Persistent, but every
+  read and write touches disk.
+- **Mnesia** ships with OTP and gives you both, plus distribution,
+  transactions, and a schema — more than most single-node apps need.
+- **shelf** combines ETS-speed reads with DETS-backed persistence, without a
+  distributed database to run.
+
 ## Built in
 
 <dl class="splash-features">

--- a/website/src/content/docs/installation.mdx
+++ b/website/src/content/docs/installation.mdx
@@ -3,10 +3,6 @@ title: Installation
 description: How to install shelf in your Gleam project.
 ---
 
-import PreReleaseNotice from '../../components/PreReleaseNotice.astro';
-
-<PreReleaseNotice />
-
 Add shelf to your Gleam project:
 
 ```bash

--- a/website/src/content/docs/introduction.mdx
+++ b/website/src/content/docs/introduction.mdx
@@ -3,10 +3,6 @@ title: What is shelf?
 description: An introduction to shelf and persistent ETS tables.
 ---
 
-import PreReleaseNotice from '../../components/PreReleaseNotice.astro';
-
-<PreReleaseNotice />
-
 shelf combines **ETS** (fast, in-memory) with **DETS** (persistent, on-disk) to give you microsecond reads with durable storage. It implements the classic Erlang persistence pattern, wrapped in a type-safe Gleam API.
 
 ## How it works

--- a/website/src/content/docs/quick-start.mdx
+++ b/website/src/content/docs/quick-start.mdx
@@ -3,10 +3,6 @@ title: Quick Start
 description: Get up and running with shelf in minutes.
 ---
 
-import PreReleaseNotice from '../../components/PreReleaseNotice.astro';
-
-<PreReleaseNotice />
-
 This guide walks you through basic persistent ETS operations with shelf.
 
 ## 1. Add shelf to your project

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -12,6 +12,45 @@
 	--sl-color-gray-6: #4d0022;
 	--sl-color-black: #340014;
 }
+/* Site-wide reading refinements. */
+.sl-markdown-content :is(h1, h2, h3),
+.hero .tagline {
+	text-wrap: balance;
+}
+.sl-markdown-content p {
+	text-wrap: pretty;
+}
+
+/* Splash page: landing rhythm — generous section separation, capped prose measure.
+   Guides keep Starlight's 65ch column; only the hero page runs full-bleed. */
+[data-has-hero] .sl-markdown-content h2 {
+	margin-top: clamp(3rem, 8vw, 4rem);
+}
+[data-has-hero] .sl-markdown-content p:not(.starlight-aside *) {
+	max-width: 70ch;
+}
+
+/* Splash feature list — quiet definition grid, no card chrome. */
+.splash-features {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	gap: 1.75rem 2.5rem;
+	margin-top: 1.5rem;
+}
+.splash-features > div {
+	margin: 0;
+}
+.splash-features dt {
+	font-weight: 650;
+	color: var(--sl-color-white);
+}
+.splash-features dd {
+	margin: 0.375rem 0 0;
+	padding: 0;
+	font-size: var(--sl-text-sm);
+	line-height: 1.6;
+}
+
 /* Light mode colors. */
 :root[data-theme='light'] {
 	--sl-color-accent-low: #eeccd9;

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -26,7 +26,7 @@
 [data-has-hero] .sl-markdown-content h2 {
 	margin-top: clamp(3rem, 8vw, 4rem);
 }
-[data-has-hero] .sl-markdown-content p:not(.starlight-aside *) {
+[data-has-hero] .sl-markdown-content :is(p, ul, ol):not(.starlight-aside *) {
 	max-width: 70ch;
 }
 

--- a/website/src/styles/fonts.css
+++ b/website/src/styles/fonts.css
@@ -1,3 +1,16 @@
 :root {
-	--sl-font: "Metropolis", sans-serif;
+	--sl-font: "Spline Sans Variable", "Spline Sans", sans-serif;
+	--sl-font-mono: "Spline Sans Mono Variable", "Spline Sans Mono",
+		ui-monospace, monospace;
+}
+
+/* Spline Sans sits slightly compact; give long-form prose a touch more air. */
+.sl-markdown-content {
+	line-height: 1.65;
+}
+
+/* Confident headings: use the variable range instead of a flat 600. */
+.sl-markdown-content :is(h1, h2, h3),
+.hero h1 {
+	font-weight: 650;
 }


### PR DESCRIPTION
## What changed

**Typography** — Replaces Metropolis with the Spline Sans superfamily (`@fontsource-variable/spline-sans` + `spline-sans-mono`). The site previously never set `--sl-font-mono`, so all code — the most-read content on the site — rendered in the browser's default mono stack. Code now renders in Spline Sans Mono (including Expressive Code blocks, which inherit it via `--sl-font-mono`). Headings use the variable weight axis (650); long-form prose gets a 1.65 line-height.

**Splash page** (`index.mdx`) — Removes a dead gradient-text style block (the `//` comment made the CSS rule invalid, so it never rendered) and replaces the seven identical feature cards with a real `shelf/set` code sample plus a quiet definition-list feature grid. Same feature content, tightened copy.

**Layout** — Splash-only refinements scoped via `[data-has-hero]`: prose capped at 70ch (was ~95ch full-bleed), fluid section spacing (`clamp(3rem, 8vw, 4rem)`), balanced heading/tagline wrapping. Guide pages already measure 65ch and are untouched.

**Design context** — Adds `PRODUCT.md` and `DESIGN.md` capturing the site's strategy and visual system (berry/ink palette, type rules), plus `.impeccable/` config consumed by the design tooling.

**Build fix** — `website/pnpm-workspace.yaml` had placeholder values in `allowBuilds` ("set this to true or false"), which made every pnpm command fail under pnpm 11; now set to `true` for esbuild/sharp.
